### PR TITLE
feat: 猫モード（nyaize）相当のテキスト変換に対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Nyaize（猫モード相当のテキスト変換）に対応
+  - `nyaize(String)` 純粋関数を公開API（`misskey_mfm_renderer` から直接 import 可）
+  - 日本語 / 英語 / 韓国語の3言語で本家 Misskey と同等の変換規則
+  - `MfmRenderConfig.enableNyaize` を `true` にすると `MfmText` のテキストノードへ自動適用
+  - `link` / `quote` / `plain` 配下のサブツリーは本家挙動に準拠して変換対象外
+  - URL / メンション / ハッシュタグ / 各種コード / 数式 / 絵文字 / 検索ノードは構造上テキストノードを経由しないため自然と除外
+
 ## 0.1.0 - 2026-02-09
 
 Initial release of misskey_mfm_renderer - A Flutter widget library for rendering Misskey MFM (Misskey Flavored Markdown) content.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ integration work.
 
 **Not Yet Implemented:**
 - **Math Rendering**: LaTeX formulas are displayed as plain text. Full math rendering with KaTeX or similar library is planned for future releases.
-- **Nyaize**: Text transformation feature (converting certain characters to "nya") is not yet implemented.
 - **Font Limitations**: Some font types in `$[font.xxx]` syntax (specifically `emoji` and `math`) fall back to default fonts due to platform limitations.
+
+**Nyaize (Cat-speak transformation)**: Text transformation feature is supported via `enableNyaize`.
+Equivalent to Misskey's cat mode, it converts text in text nodes to cat-speak (ja-JP / en-US / ko-KR).
+Subtrees of `link` / `quote` / `plain` are excluded from transformation (matching Misskey's upstream behavior).
+The `nyaize(String)` pure function is also exposed publicly.
 
 ### Custom Emoji Support
 
@@ -359,7 +363,7 @@ void main() {
 | `baseTextStyle` | `TextStyle?` | null | Base text style |
 | `enableAdvancedMfm` | `bool` | true | Enable advanced features like position |
 | `enableAnimation` | `bool` | true | Enable animations (for future use) |
-| `enableNyaize` | `bool` | false | Enable nyaize transformation (for future use) |
+| `enableNyaize` | `bool` | false | Enable nyaize (cat-speak) transformation on text nodes |
 | `emojiBuilder` | `Widget Function(String)?` | null | Custom emoji builder |
 | `unicodeEmojiBuilder` | `Widget Function(String)?` | null | Unicode emoji builder |
 | `onLinkTap` | `void Function(String)?` | null | Link tap callback |
@@ -439,8 +443,12 @@ MFMを完全に描画できるようにするため、`misskey_emoji` を依存�
 
 **未実装の機能:**
 - **数式レンダリング**: LaTeX数式はプレーンテキストで表示されます。KaTeXなどのライブラリを使った完全な数式レンダリングは将来のリリースで対応予定です。
-- **Nyaize**: 特定の文字を「にゃ」に変換するテキスト変換機能は未実装です。（今後実装予定）
 - **フォントの制限**: `$[font.xxx]` 構文の一部のフォントタイプ（特に `emoji` と `math`）は、プラットフォームの制限によりデフォルトフォントにフォールバックします。代替策を検討中です。
+
+**Nyaize（猫モード相当のテキスト変換）**: `enableNyaize` で有効化されます。
+Misskeyの猫モードと同等の挙動で、テキストノードの文字列を猫語に変換します（ja-JP / en-US / ko-KR の3言語）。
+`link` / `quote` / `plain` 配下のサブツリーは変換対象外（本家挙動に準拠）。
+`nyaize(String)` 純粋関数も公開APIとして利用できます。
 
 ### カスタム絵文字対応
 
@@ -748,7 +756,7 @@ void main() {
 | `baseTextStyle` | `TextStyle?` | null | ベースのテキストスタイル |
 | `enableAdvancedMfm` | `bool` | true | position等の高度な機能を有効化 |
 | `enableAnimation` | `bool` | true | アニメーションを有効化（今後実装） |
-| `enableNyaize` | `bool` | false | nyaize変換を有効化（今後実装） |
+| `enableNyaize` | `bool` | false | nyaize（猫語）変換をテキストノードに対して有効化 |
 | `emojiBuilder` | `Widget Function(String)?` | null | カスタム絵文字ビルダー |
 | `unicodeEmojiBuilder` | `Widget Function(String)?` | null | Unicode絵文字ビルダー |
 | `onLinkTap` | `void Function(String)?` | null | リンクタップコールバック |

--- a/lib/misskey_mfm_renderer.dart
+++ b/lib/misskey_mfm_renderer.dart
@@ -10,4 +10,5 @@ export 'src/config/mfm_inherited_config.dart';
 export 'src/config/mfm_render_config.dart';
 export 'src/helpers/emoji_config.dart';
 export 'src/mfm_text.dart';
+export 'src/utils/nyaize.dart';
 export 'src/widgets/mfm_custom_emoji.dart';

--- a/lib/src/builder/mfm_node_builder.dart
+++ b/lib/src/builder/mfm_node_builder.dart
@@ -6,11 +6,16 @@ import 'package:misskey_mfm_parser/misskey_mfm_parser.dart';
 
 import '../config/mfm_render_config.dart';
 import '../fn/mfm_fn_handler.dart';
+import '../utils/nyaize.dart';
 import '../widgets/mfm_code_block.dart';
 
 /// MfmNodeをWidgetに変換するビルダー
 class MfmNodeBuilder {
-  MfmNodeBuilder({required this.config, this.scale = 1.0});
+  MfmNodeBuilder({
+    required this.config,
+    this.scale = 1.0,
+    this.disableNyaize = false,
+  });
 
   /// レンダリング設定
   final MfmRenderConfig config;
@@ -18,10 +23,27 @@ class MfmNodeBuilder {
   /// 現在のスケール（ネストしたscale fnで使用）
   final double scale;
 
+  /// 現在のサブツリーで nyaize 変換を抑止するか
+  /// link / quote / plain など、原文を保ちたいノード配下では true となる
+  final bool disableNyaize;
+
   /// 新しいスケールでビルダーをコピー
   MfmNodeBuilder withScale(double newScale) {
-    return MfmNodeBuilder(config: config, scale: newScale);
+    return MfmNodeBuilder(
+      config: config,
+      scale: newScale,
+      disableNyaize: disableNyaize,
+    );
   }
+
+  /// nyaize 変換を抑止したサブツリー用ビルダーを返す
+  MfmNodeBuilder _withDisableNyaize() {
+    if (disableNyaize) return this;
+    return MfmNodeBuilder(config: config, scale: scale, disableNyaize: true);
+  }
+
+  /// 現在の文脈で nyaize 変換を適用すべきか
+  bool get _shouldNyaize => config.enableNyaize && !disableNyaize;
 
   /// ノードリストをWidgetリストに変換
   List<InlineSpan> buildNodes(List<MfmNode> nodes) {
@@ -57,7 +79,8 @@ class MfmNodeBuilder {
   InlineSpan _buildText(TextNode node) {
     // styleをnullにして親のスタイルを継承
     // ルートのTextSpanでbaseTextStyleが設定されているため、ここで再設定する必要はない
-    return TextSpan(text: node.text);
+    final text = _shouldNyaize ? nyaize(node.text) : node.text;
+    return TextSpan(text: text);
   }
 
   InlineSpan _buildBold(BoldNode node) {
@@ -99,7 +122,7 @@ class MfmNodeBuilder {
   }
 
   InlineSpan _buildQuote(QuoteNode node) {
-    final children = buildNodes(node.children);
+    final children = _withDisableNyaize().buildNodes(node.children);
     final baseColor = config.baseTextStyle?.color;
 
     return WidgetSpan(
@@ -251,7 +274,7 @@ class MfmNodeBuilder {
   }
 
   InlineSpan _buildLink(LinkNode node) {
-    final children = buildNodes(node.children);
+    final children = _withDisableNyaize().buildNodes(node.children);
     final onLinkTap = config.onLinkTap;
     return TextSpan(
       style: const TextStyle(
@@ -368,7 +391,7 @@ class MfmNodeBuilder {
   }
 
   InlineSpan _buildPlain(PlainNode node) {
-    final children = buildNodes(node.children);
+    final children = _withDisableNyaize().buildNodes(node.children);
     return TextSpan(children: children);
   }
 

--- a/lib/src/utils/nyaize.dart
+++ b/lib/src/utils/nyaize.dart
@@ -1,0 +1,56 @@
+/// テキストを「猫語」に変換する純粋関数
+///
+/// Misskey本家 `packages/misskey-js/src/nyaize.ts` を Dart に移植したもの。
+/// 日本語/英語/韓国語の3言語に対応する。
+///
+/// 仕様の概要:
+/// - ja-JP: 「な/ナ/ﾅ」をそれぞれ「にゃ/ニャ/ﾆｬ」に置換
+/// - en-US:
+///   - 「n」の直後の「a」を「ya」（大文字なら「YA」）へ
+///   - 「morn」の直後の「ing」を「yan」（全大文字なら「YAN」）へ
+///   - 「every」の直後の「one」を「nyan」（全大文字なら「NYAN」）へ
+/// - ko-KR:
+///   - 「나-낳」を「냐-냫」へ（同オフセットでシフト）
+///   - 文末や記号直前の「다」を「다냥」へ
+///   - 同位置の「야」を「냥」へ
+final _enRegex1 = RegExp('(?<=n)a', caseSensitive: false);
+final _enRegex2 = RegExp('(?<=morn)ing', caseSensitive: false);
+final _enRegex3 = RegExp('(?<=every)one', caseSensitive: false);
+final _koRegex1 = RegExp('[나-낳]');
+final _koRegex2 = RegExp(r'(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))',
+    multiLine: true);
+final _koRegex3 = RegExp(r'(야(?=\?))|(야$)|(야(?= ))', multiLine: true);
+
+// '냐' (U+B0D0) - '나' (U+B098) = 56。Hangul音節ブロックでの
+// 母音「ㅏ」→「ㅑ」へのシフト量（終声28通り × 母音2ステップ）。
+const int _koOffset = 0xB0D0 - 0xB098;
+
+/// テキストを猫語へ変換して返す
+String nyaize(String text) {
+  var result = text
+      .replaceAll('な', 'にゃ')
+      .replaceAll('ナ', 'ニャ')
+      .replaceAll('ﾅ', 'ﾆｬ');
+
+  result = result.replaceAllMapped(_enRegex1, (m) {
+    final matched = m.group(0)!;
+    return matched == 'A' ? 'YA' : 'ya';
+  });
+  result = result.replaceAllMapped(_enRegex2, (m) {
+    final matched = m.group(0)!;
+    return matched == 'ING' ? 'YAN' : 'yan';
+  });
+  result = result.replaceAllMapped(_enRegex3, (m) {
+    final matched = m.group(0)!;
+    return matched == 'ONE' ? 'NYAN' : 'nyan';
+  });
+
+  result = result.replaceAllMapped(_koRegex1, (m) {
+    final code = m.group(0)!.codeUnitAt(0);
+    return String.fromCharCode(code + _koOffset);
+  });
+  result = result.replaceAll(_koRegex2, '다냥');
+  result = result.replaceAll(_koRegex3, '냥');
+
+  return result;
+}

--- a/test/unit/nyaize_test.dart
+++ b/test/unit/nyaize_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+void main() {
+  group('nyaize / ja-JP', () {
+    test('「な」を「にゃ」に置換する', () {
+      expect(nyaize('なにぬねの'), 'にゃにぬねの');
+    });
+
+    test('全角カタカナ「ナ」を「ニャ」に置換する', () {
+      expect(nyaize('ナニヌネノ'), 'ニャニヌネノ');
+    });
+
+    test('半角カタカナ「ﾅ」を「ﾆｬ」に置換する', () {
+      expect(nyaize('ﾅﾆﾇﾈﾉ'), 'ﾆｬﾆﾇﾈﾉ');
+    });
+
+    test('複数箇所を一括で置換する', () {
+      expect(nyaize('あなたとなかよく'), 'あにゃたとにゃかよく');
+    });
+  });
+
+  group('nyaize / en-US', () {
+    test('「n」の直後の「a」を「ya」に置換する', () {
+      // b-a は対象外（直前がbのため）。n-a は2箇所とも対象。
+      expect(nyaize('banana'), 'banyanya');
+    });
+
+    test('大文字「A」を「YA」、小文字「a」を「ya」に置換する', () {
+      expect(nyaize('NAna'), 'NYAnya');
+    });
+
+    test('「morning」を「mornyan」に置換する', () {
+      expect(nyaize('morning'), 'mornyan');
+    });
+
+    test('全大文字「MORNING」を「MORNYAN」に置換する', () {
+      expect(nyaize('MORNING'), 'MORNYAN');
+    });
+
+    test('「everyone」を「everynyan」に置換する', () {
+      expect(nyaize('everyone'), 'everynyan');
+    });
+
+    test('全大文字「EVERYONE」を「EVERYNYAN」に置換する', () {
+      expect(nyaize('EVERYONE'), 'EVERYNYAN');
+    });
+
+    test('「n」を伴わない「a」は置換しない', () {
+      expect(nyaize('apple'), 'apple');
+    });
+  });
+
+  group('nyaize / ko-KR', () {
+    test('「나」を「냐」に置換する', () {
+      expect(nyaize('나'), '냐');
+    });
+
+    test('「낳」を「냫」に置換する（範囲端）', () {
+      expect(nyaize('낳'), '냫');
+    });
+
+    test('文末の「다」を「다냥」に置換する', () {
+      expect(nyaize('먹는다'), '먹는다냥');
+    });
+
+    test('ピリオド直前の「다」を「다냥」に置換する', () {
+      expect(nyaize('먹는다.'), '먹는다냥.');
+    });
+
+    test('文末の「야」を「냥」に置換する', () {
+      expect(nyaize('뭐야'), '뭐냥');
+    });
+
+    test('?直前の「야」を「냥」に置換する', () {
+      expect(nyaize('뭐야?'), '뭐냥?');
+    });
+  });
+
+  group('nyaize / 副作用がない', () {
+    test('対象文字を含まない文字列は変化しない', () {
+      expect(nyaize('hello world'), 'hello world');
+    });
+
+    test('空文字は空文字のまま', () {
+      expect(nyaize(''), '');
+    });
+  });
+}

--- a/test/widget/mfm_nyaize_test.dart
+++ b/test/widget/mfm_nyaize_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+void main() {
+  group('MfmText / nyaize 適用', () {
+    testWidgets('enableNyaize=false の場合は変換しない（デフォルト）', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: 'なにぬねの'),
+          ),
+        ),
+      );
+
+      expect(_findSpanWithText(_rootSpan(tester), 'なにぬねの'), isNotNull);
+      expect(_findSpanWithText(_rootSpan(tester), 'にゃにぬねの'), isNull);
+    });
+
+    testWidgets('enableNyaize=true の場合はテキストノードが変換される', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: 'なにぬねの',
+              config: MfmRenderConfig(enableNyaize: true),
+            ),
+          ),
+        ),
+      );
+
+      expect(_findSpanWithText(_rootSpan(tester), 'にゃにぬねの'), isNotNull);
+    });
+
+    testWidgets('inlineCode の中身は変換されない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: 'なにぬ`なにぬ`なにぬ',
+              config: MfmRenderConfig(enableNyaize: true),
+            ),
+          ),
+        ),
+      );
+
+      // インラインコードの内側はWidgetSpan経由でTextウィジェットとして描画されるため、
+      // 元のテキストがそのまま画面上に存在することを確認する
+      expect(find.text('なにぬ'), findsOneWidget);
+    });
+
+    testWidgets('plain タグの中身は変換されない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '<plain>なにぬねの</plain>',
+              config: MfmRenderConfig(enableNyaize: true),
+            ),
+          ),
+        ),
+      );
+
+      // plain サブツリーは原文のまま、外側のテキストノードのみ変換される
+      expect(_findSpanWithText(_rootSpan(tester), 'なにぬねの'), isNotNull);
+    });
+
+    testWidgets('quote の中身は変換されない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '> なにぬねの',
+              config: MfmRenderConfig(enableNyaize: true),
+            ),
+          ),
+        ),
+      );
+
+      // quote 配下は原文のまま保持されることを確認
+      // QuoteNode は WidgetSpan として描画されるため、ウィジェットツリーから探す
+      final richTexts = tester.widgetList<RichText>(find.byType(RichText));
+      final hasOriginal = richTexts.any(
+        (rt) => _findSpanWithText(rt.text as TextSpan, 'なにぬねの') != null,
+      );
+      expect(hasOriginal, isTrue);
+    });
+
+    testWidgets('リンクのラベルは変換されない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '[なにぬ](https://example.com)',
+              config: MfmRenderConfig(enableNyaize: true),
+            ),
+          ),
+        ),
+      );
+
+      expect(_findSpanWithText(_rootSpan(tester), 'なにぬ'), isNotNull);
+      expect(_findSpanWithText(_rootSpan(tester), 'にゃにぬ'), isNull);
+    });
+  });
+}
+
+TextSpan _rootSpan(WidgetTester tester) {
+  final richText = tester.widget<RichText>(find.byType(RichText).first);
+  return richText.text as TextSpan;
+}
+
+TextSpan? _findSpanWithText(TextSpan parent, String text) {
+  if (parent.text == text) {
+    return parent;
+  }
+  if (parent.children != null) {
+    for (final child in parent.children!) {
+      if (child is TextSpan) {
+        final found = _findSpanWithText(child, text);
+        if (found != null) {
+          return found;
+        }
+      }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Misskey本家の Cat mode と同等のテキスト変換（nyaize）に対応
- `MfmRenderConfig.enableNyaize` で有効化、`link` / `quote` / `plain` 配下は本家挙動に準拠して変換対象外
- `nyaize(String)` 純粋関数も公開APIから直接利用可能

## 変更内容

### 追加
- `lib/src/utils/nyaize.dart`: misskey-js の `nyaize.ts` を Dart に移植した純粋関数
  - ja-JP: `な` / `ナ` / `ﾅ` → `にゃ` / `ニャ` / `ﾆｬ`
  - en-US: `n` 直後の `a` → `ya`、`morning` → `mornyan`、`everyone` → `everynyan`（大文字版も大文字で出力）
  - ko-KR: `나-낳` → `냐-냫`、文末/記号直前の `다` / `야` → `다냥` / `냥`
- `test/unit/nyaize_test.dart`: 純粋関数の単体テスト（19件）
- `test/widget/mfm_nyaize_test.dart`: ビルダー統合テスト（6件、除外ルール検証含む）

### 変更
- `lib/src/builder/mfm_node_builder.dart`: `disableNyaize` フラグを導入し、`link` / `quote` / `plain` のサブツリーに伝播
- `lib/misskey_mfm_renderer.dart`: `nyaize` 関数を公開APIへ export
- `README.md`: 未実装ステータスを解消、英日両方のドキュメントを更新
- `CHANGELOG.md`: `## Unreleased` セクションを追加

## 除外ルール（本家準拠）
| ノード種別 | 変換 | 仕組み |
|---|---|---|
| `text` | 適用 | `enableNyaize=true` かつ `disableNyaize=false` の場合 |
| `link` / `quote` / `plain` | 抑止 | サブツリーに `disableNyaize=true` を伝播 |
| `url` / `mention` / `hashtag` / `inlineCode` / `codeBlock` / `mathInline` / `mathBlock` / `emojiCode` / `unicodeEmoji` / `search` | 抑止 | 構造上 text ノードを経由しないため自然除外 |

## 参考
- Misskey本家実装: [packages/misskey-js/src/nyaize.ts](https://github.com/misskey-dev/misskey/blob/develop/packages/misskey-js/src/nyaize.ts)
- 本家フロントでの適用箇所: [packages/frontend/src/components/global/MkMfm.ts](https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/components/global/MkMfm.ts)