### PR TITLE
fix: pubspec.yaml の repository フィールドを正しいURLに修正

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: misskey_mfm_renderer
 description: Flutter widget renderer for Misskey MFM (Misskey Flavored Markdown)
 version: 0.1.0
-repository: https://github.com/your-repo/misskey_mfm_renderer
+repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Summary
- `pubspec.yaml` の `repository` フィールドがプレースホルダー（`https://github.com/your-repo/...`）のままだったため、実リポジトリのURLへ修正

## 変更内容
```diff
-repository: https://github.com/your-repo/misskey_mfm_renderer
+repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
```

## 背景
- pub.dev 公開時に追加された `repository` フィールドがテンプレート値のままだった
- pub.dev のパッケージページから「Repository」リンク経由で正しいGitHubリポジトリへ遷移できるようにする
- ライブラリの実行時挙動には影響しないメタデータのみの変更

## CHANGELOG への記載について
本PRはメタデータのみの修正で実行時挙動に影響しないため、CHANGELOG への記載は省略している。