### PR TITLE
chore: 0.2.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.2.0 - 2026-05-16
 
 ### Added
 - Nyaize（猫モード相当のテキスト変換）に対応

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: misskey_mfm_renderer
 description: Flutter widget renderer for Misskey MFM (Misskey Flavored Markdown)
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
 
 environment:


### PR DESCRIPTION
## Summary
- バージョンを 0.2.0 にバンプし、CHANGELOG の節を確定する
- リリース内容の主軸は #1（猫モード対応）で、副次的に #2（repository URL修正）を同梱

## 変更内容
- `pubspec.yaml`: `version: 0.1.0` → `0.2.0`
- `CHANGELOG.md`: `## Unreleased` を `## 0.2.0 - 2026-05-16` として確定
- `example/pubspec.lock`: 参照バージョンを追従

## 含まれる変更（v0.1.0 からの差分）
| PR | 種別 | 内容 |
|---|---|---|
| #1 | feat | 猫モード（nyaize）相当のテキスト変換に対応 |
| #2 | fix | pubspec.yaml の repository フィールドを正しいURLに修正 |

詳細は `CHANGELOG.md` の `## 0.2.0 - 2026-05-16` セクションを参照。

## SemVer 上の位置付け
- 新規公開API追加（`nyaize(String)` 関数 / `enableNyaize` の実装）のため MINOR バンプ
- 既存利用者の挙動は変わらない後方互換変更（`enableNyaize` のデフォルトは `false`）