### PR TITLE
fix: speed境界値でアニメーションが失敗する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- アニメーション関数の `speed` が0以下または1ms未満の場合に描画が失敗する問題を修正
+- 負の `delay` を本家Misskeyと同様に経過済み時間として反映
+
 ## 0.2.0 - 2026-05-16
 
 ### Added

--- a/lib/src/fn/animated/mfm_animated_wrapper.dart
+++ b/lib/src/fn/animated/mfm_animated_wrapper.dart
@@ -10,6 +10,77 @@ typedef MfmAnimatedBuilder =
       Animation<double> progress,
     );
 
+class _MfmRepeatingProgressAnimation extends Animation<double> {
+  _MfmRepeatingProgressAnimation({
+    required this.parent,
+    required this.period,
+    required this.delay,
+    required this.reverse,
+    required this.curve,
+    required this.reverseCurve,
+  });
+
+  final AnimationController parent;
+  final Duration period;
+  final Duration delay;
+  final bool reverse;
+  final Curve curve;
+  final Curve reverseCurve;
+
+  int get _elapsedMicroseconds {
+    final elapsed = parent.lastElapsedDuration?.inMicroseconds ?? 0;
+    final skipped = delay.isNegative ? -delay.inMicroseconds : 0;
+    return elapsed + skipped;
+  }
+
+  bool get _isPlayingReverse {
+    if (!reverse || period <= Duration.zero) {
+      return false;
+    }
+    return (_elapsedMicroseconds ~/ period.inMicroseconds).isOdd;
+  }
+
+  @override
+  double get value {
+    if (period <= Duration.zero) {
+      return 0;
+    }
+
+    final fraction =
+        (_elapsedMicroseconds % period.inMicroseconds) / period.inMicroseconds;
+    final isPlayingReverse = _isPlayingReverse;
+    final directedValue = isPlayingReverse ? 1 - fraction : fraction;
+    final activeCurve = isPlayingReverse ? reverseCurve : curve;
+    return activeCurve.transform(directedValue);
+  }
+
+  @override
+  AnimationStatus get status {
+    if (!parent.isAnimating) {
+      return parent.status;
+    }
+    return _isPlayingReverse
+        ? AnimationStatus.reverse
+        : AnimationStatus.forward;
+  }
+
+  @override
+  void addListener(VoidCallback listener) => parent.addListener(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => parent.removeListener(listener);
+
+  @override
+  void addStatusListener(AnimationStatusListener listener) {
+    parent.addStatusListener(listener);
+  }
+
+  @override
+  void removeStatusListener(AnimationStatusListener listener) {
+    parent.removeStatusListener(listener);
+  }
+}
+
 /// MFMアニメーションの共通ラッパー
 ///
 /// - 有効/無効の制御
@@ -40,7 +111,10 @@ class MfmAnimatedWrapper extends StatefulWidget {
   final Curve curve;
   final Curve? reverseCurve;
 
-  /// `value` は num（秒）または "1.5s" の形式を受け付ける
+  /// `value` は num（秒）または "1.5s" の形式を受け付ける。
+  ///
+  /// 未指定・不正値は null、有限の数値は符号を保った Duration を返す。
+  /// 正の極小値を失わないよう、マイクロ秒単位で変換する。
   static Duration? parseTime(Object? value) {
     if (value == null) return null;
     if (value is Duration) return value;
@@ -62,8 +136,7 @@ class MfmAnimatedWrapper extends StatefulWidget {
       return null;
     }
 
-    final safeSeconds = seconds < 0 ? 0.0 : seconds;
-    return Duration(milliseconds: (safeSeconds * 1000).round());
+    return Duration(microseconds: (seconds * 1000000).round());
   }
 
   /// `parseTime` の結果が null の場合に `fallback` を返す。
@@ -90,11 +163,15 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
   late Animation<double> _progress;
   Timer? _delayTimer;
 
+  Duration get _controllerDuration => widget.duration > Duration.zero
+      ? widget.duration
+      : const Duration(microseconds: 1);
+
   @override
   void initState() {
     super.initState();
     _controller = AnimationController(
-      duration: widget.duration,
+      duration: _controllerDuration,
       vsync: this,
     );
     _updateProgress();
@@ -105,12 +182,17 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
   void didUpdateWidget(covariant MfmAnimatedWrapper oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (oldWidget.duration != widget.duration) {
-      _controller.duration = widget.duration;
+    final durationChanged = oldWidget.duration != widget.duration;
+    if (durationChanged) {
+      _controller.duration = _controllerDuration;
     }
 
     if (oldWidget.curve != widget.curve ||
-        oldWidget.reverseCurve != widget.reverseCurve) {
+        oldWidget.reverseCurve != widget.reverseCurve ||
+        oldWidget.delay != widget.delay ||
+        oldWidget.repeat != widget.repeat ||
+        oldWidget.reverse != widget.reverse ||
+        durationChanged) {
       setState(_updateProgress);
     }
 
@@ -118,7 +200,8 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
         oldWidget.enabled != widget.enabled ||
         oldWidget.delay != widget.delay ||
         oldWidget.repeat != widget.repeat ||
-        oldWidget.reverse != widget.reverse;
+        oldWidget.reverse != widget.reverse ||
+        durationChanged;
 
     if (shouldRestart) {
       _stopAnimation();
@@ -127,11 +210,11 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
   }
 
   void _startAnimation() {
-    if (!widget.enabled) {
+    if (!widget.enabled || widget.duration <= Duration.zero) {
       return;
     }
 
-    if (widget.delay == Duration.zero) {
+    if (widget.delay <= Duration.zero) {
       _startController();
       return;
     }
@@ -146,11 +229,25 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
   }
 
   void _startController() {
-    if (widget.repeat) {
-      _controller.repeat(reverse: widget.reverse);
+    if (!widget.enabled || widget.duration <= Duration.zero) {
       return;
     }
-    _controller.forward();
+
+    if (widget.repeat) {
+      // 負の delay は、CSS と同様にその時間だけ進行済みの位相から
+      // 始める。位相計算は _MfmRepeatingProgressAnimation が担う。
+      _controller.repeat(
+        reverse: widget.reverse && !widget.delay.isNegative,
+      );
+      return;
+    }
+
+    final skippedMicroseconds = widget.delay.isNegative
+        ? -widget.delay.inMicroseconds
+        : 0;
+    final initialValue = (skippedMicroseconds / widget.duration.inMicroseconds)
+        .clamp(0.0, 1.0);
+    _controller.forward(from: initialValue);
   }
 
   void _stopAnimation() {
@@ -161,11 +258,22 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
   }
 
   void _updateProgress() {
-    _progress = CurvedAnimation(
-      parent: _controller,
-      curve: widget.curve,
-      reverseCurve: widget.reverseCurve ?? widget.curve,
-    );
+    if (widget.repeat && widget.delay.isNegative) {
+      _progress = _MfmRepeatingProgressAnimation(
+        parent: _controller,
+        period: widget.duration,
+        delay: widget.delay,
+        reverse: widget.reverse,
+        curve: widget.curve,
+        reverseCurve: widget.reverseCurve ?? widget.curve,
+      );
+    } else {
+      _progress = CurvedAnimation(
+        parent: _controller,
+        curve: widget.curve,
+        reverseCurve: widget.reverseCurve ?? widget.curve,
+      );
+    }
   }
 
   @override
@@ -177,7 +285,7 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.enabled) {
+    if (!widget.enabled || widget.duration <= Duration.zero) {
       return widget.child;
     }
 

--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -197,6 +197,10 @@ class MfmFnHandler {
 
     final children = builder.buildNodes(node.children);
 
+    if (duration <= Duration.zero) {
+      return TextSpan(children: children);
+    }
+
     return WidgetSpan(
       child: MfmSpinWidget(
         axis: axis,
@@ -227,6 +231,10 @@ class MfmFnHandler {
 
     final children = builder.buildNodes(node.children);
 
+    if (duration <= Duration.zero) {
+      return TextSpan(children: children);
+    }
+
     return WidgetSpan(
       child: MfmJumpWidget(
         duration: duration,
@@ -255,6 +263,10 @@ class MfmFnHandler {
 
     final children = builder.buildNodes(node.children);
 
+    if (duration <= Duration.zero) {
+      return TextSpan(children: children);
+    }
+
     return WidgetSpan(
       child: MfmBounceWidget(
         duration: duration,
@@ -277,6 +289,12 @@ class MfmFnHandler {
         const Duration(milliseconds: 1000);
     final delay = MfmAnimatedWrapper.parseTime(args['delay']) ?? Duration.zero;
     final children = builder.buildNodes(node.children);
+
+    // 本家 Misskey ではアニメーション有効時の duration=0 は
+    // rainbow の静的フォールバックを適用せず、通常の文字表示になる。
+    if (builder.config.enableAnimation && duration <= Duration.zero) {
+      return TextSpan(children: children);
+    }
 
     return WidgetSpan(
       child: MfmRainbowWidget(
@@ -322,6 +340,10 @@ class MfmFnHandler {
 
     final children = builder.buildNodes(node.children);
 
+    if (duration <= Duration.zero) {
+      return TextSpan(children: children);
+    }
+
     return WidgetSpan(
       child: MfmShakeWidget(
         duration: duration,
@@ -349,6 +371,10 @@ class MfmFnHandler {
     final delay = MfmAnimatedWrapper.parseTime(args['delay']) ?? Duration.zero;
 
     final children = builder.buildNodes(node.children);
+
+    if (duration <= Duration.zero) {
+      return TextSpan(children: children);
+    }
 
     return WidgetSpan(
       child: MfmTwitchWidget(
@@ -378,7 +404,7 @@ class MfmFnHandler {
       child: MfmTadaWidget(
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.enableAnimation && duration > Duration.zero,
         child: RichText(
           text: TextSpan(
             style: builder.config.baseTextStyle,
@@ -401,6 +427,10 @@ class MfmFnHandler {
     final delay = MfmAnimatedWrapper.parseTime(args['delay']) ?? Duration.zero;
 
     final children = builder.buildNodes(node.children);
+
+    if (duration <= Duration.zero) {
+      return TextSpan(children: children);
+    }
 
     return WidgetSpan(
       child: MfmJellyWidget(

--- a/test/widget/mfm_animation_time_test.dart
+++ b/test/widget/mfm_animation_time_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_animated_wrapper.dart';
+
+void main() {
+  group('MfmAnimatedWrapper.parseTime', () {
+    test('秒をマイクロ秒精度でパースする', () {
+      expect(
+        MfmAnimatedWrapper.parseTime('0.0004s'),
+        const Duration(microseconds: 400),
+      );
+      expect(
+        MfmAnimatedWrapper.parseTime(0.000001),
+        const Duration(microseconds: 1),
+      );
+    });
+
+    test('ゼロと負数の符号をフォールバックと区別できる', () {
+      expect(MfmAnimatedWrapper.parseTime('0s'), Duration.zero);
+      expect(
+        MfmAnimatedWrapper.parseTime('-1s'),
+        const Duration(seconds: -1),
+      );
+    });
+
+    test('Durationで表現できない極小値はゼロになる', () {
+      expect(MfmAnimatedWrapper.parseTime('0.0000004s'), Duration.zero);
+    });
+
+    test('未指定・不正値・非有限値はnullになる', () {
+      expect(MfmAnimatedWrapper.parseTime(null), isNull);
+      expect(MfmAnimatedWrapper.parseTime('invalid'), isNull);
+      expect(MfmAnimatedWrapper.parseTime(double.nan), isNull);
+      expect(MfmAnimatedWrapper.parseTime(double.infinity), isNull);
+    });
+  });
+
+  group('ゼロ以下のspeed', () {
+    const animatedFunctions = <String>[
+      'jelly',
+      'tada',
+      'jump',
+      'bounce',
+      'spin',
+      'shake',
+      'twitch',
+      'rainbow',
+    ];
+
+    for (final fn in animatedFunctions) {
+      for (final speed in <String>['0s', '-1s']) {
+        testWidgets('$fn.speed=$speed は例外なく静止表示する', (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: MfmText(text: '\$[$fn.speed=$speed test]'),
+              ),
+            ),
+          );
+
+          expect(tester.takeException(), isNull);
+          expect(find.byType(MfmAnimatedWrapper), findsNothing);
+          expect(_containsText(tester, 'test'), isTrue);
+        });
+      }
+    }
+
+    testWidgets('tadaは静止時も150%の基本スタイルを維持する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: MfmText(text: r'$[tada.speed=0s test]')),
+        ),
+      );
+
+      final hasOnePointFiveScale = tester
+          .widgetList<Transform>(find.byType(Transform))
+          .any((widget) => widget.transform.storage[0] == 1.5);
+      expect(hasOnePointFiveScale, isTrue);
+    });
+
+    testWidgets('rainbowはspeed=0sでは静的グラデーションを適用しない', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: MfmText(text: r'$[rainbow.speed=0s test]')),
+        ),
+      );
+
+      expect(find.byType(ShaderMask), findsNothing);
+      expect(_containsText(tester, 'test'), isTrue);
+    });
+
+    testWidgets('sparkleの未対応speed引数には影響しない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: MfmText(text: r'$[sparkle.speed=0s test]')),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(Stack), findsWidgets);
+    });
+  });
+
+  group('正の極小speed', () {
+    for (final fn in <String>[
+      'jelly',
+      'tada',
+      'jump',
+      'bounce',
+      'spin',
+      'shake',
+      'twitch',
+      'rainbow',
+    ]) {
+      testWidgets('$fn.speed=0.0004s は400マイクロ秒で再生する', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MfmText(text: '\$[$fn.speed=0.0004s test]'),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        final wrapper = tester.widget<MfmAnimatedWrapper>(
+          find.byType(MfmAnimatedWrapper),
+        );
+        expect(wrapper.duration, const Duration(microseconds: 400));
+
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(tester.takeException(), isNull);
+      });
+    }
+  });
+
+  group('負のdelay', () {
+    testWidgets('経過済み時間に対応する位相から開始する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'$[spin.speed=2s,delay=-0.5s test]',
+            ),
+          ),
+        ),
+      );
+
+      final transform = _animationTransform(tester);
+      expect(transform.transform.storage[0], closeTo(0, 0.000001));
+      expect(transform.transform.storage[1], closeTo(1, 0.000001));
+    });
+
+    testWidgets('alternateの逆方向区間も開始位相へ反映する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'$[spin.alternate,speed=1s,delay=-1.25s test]',
+            ),
+          ),
+        ),
+      );
+
+      var transform = _animationTransform(tester);
+      expect(transform.transform.storage[1], closeTo(-1, 0.000001));
+
+      await tester.pump(const Duration(milliseconds: 100));
+      transform = _animationTransform(tester);
+      expect(transform.transform.storage[1], lessThan(0));
+    });
+  });
+
+  group('MfmAnimatedWrapperの防御', () {
+    testWidgets('Duration.zeroではbuilderとcontrollerを開始しない', (
+      tester,
+    ) async {
+      var buildCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MfmAnimatedWrapper(
+            duration: Duration.zero,
+            child: const Text('static'),
+            builder: (context, child, controller, progress) {
+              buildCount++;
+              return child;
+            },
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(buildCount, 0);
+      expect(find.text('static'), findsOneWidget);
+      expect(tester.hasRunningAnimations, isFalse);
+    });
+
+    testWidgets('実行中にdurationがゼロへ変わると安全に停止する', (tester) async {
+      Widget buildWrapper(Duration duration) {
+        return MaterialApp(
+          home: MfmAnimatedWrapper(
+            duration: duration,
+            child: const Text('dynamic'),
+            builder: (context, child, controller, progress) => child,
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildWrapper(const Duration(seconds: 1)));
+      expect(tester.hasRunningAnimations, isTrue);
+
+      await tester.pumpWidget(buildWrapper(Duration.zero));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('dynamic'), findsOneWidget);
+      expect(tester.hasRunningAnimations, isFalse);
+    });
+  });
+}
+
+bool _containsText(WidgetTester tester, String text) {
+  return tester.widgetList<RichText>(find.byType(RichText)).any((widget) {
+    return widget.text.toPlainText().contains(text);
+  });
+}
+
+Transform _animationTransform(WidgetTester tester) {
+  return tester
+      .widgetList<Transform>(find.byType(Transform))
+      .firstWhere((widget) => widget.alignment == Alignment.center);
+}


### PR DESCRIPTION
## 概要

- アニメーション関数の `speed` が0以下の場合、既定速度へフォールバックせず静止表示するよう修正
- `0.0004s` などの正の極小値をマイクロ秒精度で保持
- 未指定・不正な `speed` は従来どおり関数ごとの既定速度へフォールバック
- 負の `delay` を本家Misskeyと同様に経過済み時間として開始位相へ反映
- durationが実行中にゼロへ変わった場合を含め、AnimationControllerの開始処理を防御

## 本家MFMとの互換性

- `speed <= 0` は逆再生せず、アニメーション効果のない静止表示
- `tada` は静止時も150%の基本スタイルを維持
- `rainbow.speed=0s` はグローバルなアニメーション無効時の静的グラデーションと区別し、通常文字として表示
- `spin.left` および `spin.alternate` の既存方向指定は維持
- `sparkle` は従来どおり `speed` の影響を受けない

## テスト

- `fvm flutter analyze`: 成功
- issue #6向け回帰テスト35件: 成功
- 既存アニメーションテスト53件: 成功
- 関連テスト合計88件: 成功
- 全体テスト: 224件成功、既存の環境依存テスト2件のみ失敗
  - `libisar.dylib` がローカル環境に存在しないことによる失敗で、本変更とは無関係

Closes #6