### PR TITLE
chore: 0.3.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.3.0 - 2026-08-08
 
 ### Added
 - カスタム絵文字に任意の最大幅を設定する `maxWidth` / `emojiMaxWidth` を追加

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.1.0
+  misskey_mfm_renderer: ^0.3.0
 ```
 
 ## Quick Start
@@ -199,7 +199,7 @@ If your project enforces direct dependencies for imported packages, add:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.1.0
+  misskey_mfm_renderer: ^0.3.0
   misskey_api_core: ^1.0.0
   path_provider: ^2.1.5
 ```
@@ -519,7 +519,7 @@ Misskeyの猫モードと同等の挙動で、テキストノードの文字列�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.1.0
+  misskey_mfm_renderer: ^0.3.0
 ```
 
 ## クイックスタート
@@ -604,7 +604,7 @@ import対象パッケージを直接依存に置きたい場合は追加して�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.1.0
+  misskey_mfm_renderer: ^0.3.0
   misskey_api_core: ^1.0.0
   path_provider: ^2.1.5
 ```

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: misskey_mfm_renderer
 description: Flutter widget renderer for Misskey MFM (Misskey Flavored Markdown)
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
 
 environment:


### PR DESCRIPTION
## Summary
- バージョンを 0.3.0 にバンプし、CHANGELOG の節を確定する
- リリース内容の主軸は #8（カスタム絵文字のアスペクト比維持 / カタログ更新時の再解決）で、#7（アニメーション speed 境界値）を同梱

## 変更内容
- `pubspec.yaml`: `version: 0.2.0` → `0.3.0`
- `CHANGELOG.md`: `## Unreleased` を `## 0.3.0 - 2026-08-08` として確定
- `README.md`: 依存関係の記載を `^0.1.0` → `^0.3.0` に更新（v0.2.0 時に未追従だった箇所を是正）
- `example/pubspec.lock`: 参照バージョンを追従

## 含まれる変更（v0.2.0 からの差分）
| PR | Issue | 種別 | 内容 |
|---|---|---|---|
| #7 | #6 | fix | アニメーション関数の `speed` 境界値処理を修正、負の `delay` を経過済み時間として反映 |
| #8 | #5 / #9 | feat / fix | カスタム絵文字のアスペクト比を維持、`maxWidth` / `refreshListenable` を追加、カタログ更新時に再解決 |

詳細は `CHANGELOG.md` の `## 0.3.0 - 2026-08-08` セクションを参照。

## SemVer 上の位置付け
- 新規公開API追加（`MfmCustomEmoji.maxWidth` / `MfmCustomEmoji.refreshListenable` / `MfmEmojiConfig` 各ファクトリの `emojiMaxWidth` / `emojiRefreshListenable`）のため MINOR バンプ
- 追加パラメータはすべて任意で、既定動作は従来どおり

## 検証
- `fvm flutter analyze`: No issues found!
- `fvm flutter test`: 230 passed / 2 failed
  - 失敗2件はいずれもローカル環境に `libisar.dylib` が無いことによる `emoji_config_test.dart` の既知の環境起因（本変更とは無関係、#8 でも同様）
- `fvm flutter pub publish --dry-run`: 未コミット差分の警告のみ（コミット済みのため解消）、アーカイブ 127 KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)