### PR TITLE
fix: カスタム絵文字読み込み時のリフローを抑制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- カスタム絵文字の既知アスペクト比を指定する `aspectRatio` を追加
+
+### Fixed
+- カスタム絵文字の読み込み中に正方形の幅を確保して本文がリフローする問題を修正
+- 判明済みのカスタム絵文字のアスペクト比を再利用し、再生成時のリフローを抑制
+
 ## 0.3.0 - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,11 +68,14 @@ Custom emoji rendering is supported through integration with the `misskey_emoji`
 - Automatic emoji metadata resolution
 - Image caching with `cached_network_image`
 - Aspect-ratio-preserving rendering with a fixed display height
+- Reuse of decoded aspect ratios to stabilize loading placeholders
 - Fallback display for unavailable emojis
 - Animated emoji support (GIF, APNG, WebP)
 
 Custom emojis use their natural width by default. To cap very wide emojis,
 pass `emojiMaxWidth` to `MfmEmojiConfig` or `maxWidth` to `MfmCustomEmoji`.
+If an image ratio is already available in application metadata, pass it to
+`MfmCustomEmoji.aspectRatio` to stabilize the very first loading layout too.
 When a custom resolver's catalog changes, pass a `Listenable` through
 `emojiRefreshListenable` or `refreshListenable` and notify it to re-resolve
 visible emojis. `MfmEmojiConfig` does this automatically after `autoSync`.
@@ -472,12 +475,15 @@ Misskeyの猫モードと同等の挙動で、テキストノードの文字列�
 - 絵文字メタデータの自動解決
 - `cached_network_image` による画像キャッシュ
 - 高さを固定し、元画像のアスペクト比を維持した表示
+- 読み込み済みアスペクト比の再利用によるプレースホルダのレイアウト安定化
 - 未取得時のフォールバック表示
 - アニメーション絵文字（GIF/APNG/WebP）に対応
 
 カスタム絵文字の幅は既定で元画像の比率に従います。極端に横長な絵文字の幅を
 制限する場合は、`MfmEmojiConfig` の `emojiMaxWidth` または
 `MfmCustomEmoji` の `maxWidth` を指定してください。
+画像比率を別のメタデータから取得済みの場合は、`MfmCustomEmoji` の
+`aspectRatio` に渡すことで初回読み込み時のレイアウトも安定します。
 独自リゾルバーのカタログを更新した場合は、`emojiRefreshListenable` または
 `refreshListenable` に渡した `Listenable` を通知すると、表示中の絵文字を
 再解決できます。`MfmEmojiConfig` は `autoSync` 完了後に自動で通知します。

--- a/lib/src/widgets/mfm_custom_emoji.dart
+++ b/lib/src/widgets/mfm_custom_emoji.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:collection';
+import 'dart:math' as math;
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
@@ -11,12 +13,17 @@ class MfmCustomEmoji extends StatefulWidget {
     required this.resolver,
     this.size = 24.0,
     this.maxWidth,
+    this.aspectRatio,
     this.refreshListenable,
     this.fallbackBuilder,
     this.errorBuilder,
     this.loadingBuilder,
   }) : assert(size > 0),
-       assert(maxWidth == null || maxWidth > 0);
+       assert(maxWidth == null || maxWidth > 0),
+       assert(
+         aspectRatio == null ||
+             (aspectRatio > 0 && aspectRatio < double.infinity),
+       );
 
   final String name;
   final EmojiResolver resolver;
@@ -29,6 +36,13 @@ class MfmCustomEmoji extends StatefulWidget {
   /// When omitted, the image uses its natural aspect ratio without a width
   /// limit, matching Misskey's standard custom emoji rendering.
   final double? maxWidth;
+
+  /// The image's known width-to-height ratio.
+  ///
+  /// Supplying this avoids layout changes even before the image is loaded for
+  /// the first time. When omitted, decoded ratios are retained in a bounded
+  /// in-memory cache and reused by later widgets for the same emoji.
+  final double? aspectRatio;
 
   /// An optional signal that causes the emoji metadata to be resolved again.
   ///
@@ -46,6 +60,12 @@ class MfmCustomEmoji extends StatefulWidget {
 }
 
 class _MfmCustomEmojiState extends State<MfmCustomEmoji> {
+  static final _LruCache<String, double> _aspectRatios = _LruCache(256);
+  static final _LruCache<_EmojiCacheKey, String> _resolvedUrls = _LruCache(
+    256,
+  );
+  static final Set<String> _observingUrls = {};
+
   late Future<EmojiImage?> _emojiFuture;
   bool _retryOnUpdate = false;
 
@@ -118,13 +138,21 @@ class _MfmCustomEmojiState extends State<MfmCustomEmoji> {
             return _fallbackWidget(context);
           }
 
+          final url = emoji.url.toString();
+          _resolvedUrls[_cacheKey] = url;
+          final suppliedAspectRatio = widget.aspectRatio;
+          if (suppliedAspectRatio != null) {
+            _aspectRatios[url] = suppliedAspectRatio;
+          }
+          _observeAspectRatio(context, url);
+
           final image = CachedNetworkImage(
-            imageUrl: emoji.url.toString(),
+            imageUrl: url,
             height: widget.size,
             fit: BoxFit.contain,
             memCacheHeight: _memCacheHeight(context),
-            placeholder: (BuildContext context, String url) =>
-                widget.loadingBuilder?.call(context) ?? _defaultLoadingWidget(),
+            placeholder: (BuildContext context, String _) =>
+                _loadingWidget(context, _aspectRatios[url]),
             errorWidget: (BuildContext context, String url, Object error) =>
                 _errorWidget(context, error),
             fadeInDuration: const Duration(milliseconds: 150),
@@ -141,9 +169,56 @@ class _MfmCustomEmojiState extends State<MfmCustomEmoji> {
           );
         }
 
-        return widget.loadingBuilder?.call(context) ?? _defaultLoadingWidget();
+        return _loadingWidget(context, _knownAspectRatio);
       },
     );
+  }
+
+  _EmojiCacheKey get _cacheKey => _EmojiCacheKey(
+    resolver: widget.resolver,
+    name: widget.name,
+  );
+
+  double? get _knownAspectRatio {
+    final suppliedAspectRatio = widget.aspectRatio;
+    if (suppliedAspectRatio != null) {
+      return suppliedAspectRatio;
+    }
+    final url = _resolvedUrls[_cacheKey];
+    return url == null ? null : _aspectRatios[url];
+  }
+
+  void _observeAspectRatio(BuildContext context, String url) {
+    if (_aspectRatios[url] != null || !_observingUrls.add(url)) {
+      return;
+    }
+
+    final imageProvider = ResizeImage.resizeIfNeeded(
+      null,
+      _memCacheHeight(context),
+      CachedNetworkImageProvider(url),
+    );
+    final stream = imageProvider.resolve(
+      createLocalImageConfiguration(context),
+    );
+    late final ImageStreamListener listener;
+    listener = ImageStreamListener(
+      (imageInfo, _) {
+        stream.removeListener(listener);
+        _MfmCustomEmojiState._observingUrls.remove(url);
+
+        final width = imageInfo.image.width;
+        final height = imageInfo.image.height;
+        if (width > 0 && height > 0) {
+          _MfmCustomEmojiState._aspectRatios[url] = width / height;
+        }
+      },
+      onError: (Object _, StackTrace? _) {
+        stream.removeListener(listener);
+        _MfmCustomEmojiState._observingUrls.remove(url);
+      },
+    );
+    stream.addListener(listener);
   }
 
   int _memCacheHeight(BuildContext context) {
@@ -152,9 +227,19 @@ class _MfmCustomEmojiState extends State<MfmCustomEmoji> {
     return (widget.size * devicePixelRatio).ceil();
   }
 
-  Widget _defaultLoadingWidget() {
+  Widget _loadingWidget(BuildContext context, double? aspectRatio) {
+    return widget.loadingBuilder?.call(context) ??
+        _defaultLoadingWidget(aspectRatio);
+  }
+
+  Widget _defaultLoadingWidget(double? aspectRatio) {
+    final maxWidth = widget.maxWidth;
+    final width = aspectRatio == null
+        ? maxWidth ?? 0.0
+        : math.min(widget.size * aspectRatio, maxWidth ?? double.infinity);
+
     return SizedBox(
-      width: widget.size,
+      width: width,
       height: widget.size,
       child: const Center(
         child: SizedBox(
@@ -179,5 +264,48 @@ class _MfmCustomEmojiState extends State<MfmCustomEmoji> {
   Widget _errorWidget(BuildContext context, Object error) {
     return widget.errorBuilder?.call(context, widget.name, error) ??
         _fallbackWidget(context);
+  }
+}
+
+class _EmojiCacheKey {
+  const _EmojiCacheKey({
+    required this.resolver,
+    required this.name,
+  });
+
+  final EmojiResolver resolver;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _EmojiCacheKey &&
+      other.resolver == resolver &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(resolver, name);
+}
+
+class _LruCache<K, V> {
+  _LruCache(this.maximumSize) : assert(maximumSize > 0);
+
+  final int maximumSize;
+  final LinkedHashMap<K, V> _values = LinkedHashMap<K, V>();
+
+  V? operator [](K key) {
+    if (!_values.containsKey(key)) {
+      return null;
+    }
+    final value = _values.remove(key) as V;
+    _values[key] = value;
+    return value;
+  }
+
+  void operator []=(K key, V value) {
+    _values.remove(key);
+    _values[key] = value;
+    if (_values.length > maximumSize) {
+      _values.remove(_values.keys.first);
+    }
   }
 }

--- a/test/unit/mfm_custom_emoji_test.dart
+++ b/test/unit/mfm_custom_emoji_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -80,6 +82,7 @@ void main() {
       expect(image.fit, BoxFit.contain);
       expect(image.memCacheWidth, isNull);
       expect(image.memCacheHeight, 64);
+      expect(image.imageBuilder, isNull);
     });
 
     testWidgets('最大幅を指定した場合のみ画像の幅を制約する', (tester) async {
@@ -115,6 +118,115 @@ void main() {
             widget is ConstrainedBox && widget.constraints.maxWidth == 70,
       );
       expect(widthConstraint, findsOneWidget);
+    });
+
+    testWidgets('未知の絵文字の読み込み中は正方形の幅を確保しない', (tester) async {
+      final pending = Completer<EmojiImage?>();
+      Future<EmojiImage?> resolver(String _) => pending.future;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmCustomEmoji(
+              name: 'unknown-size',
+              resolver: resolver,
+            ),
+          ),
+        ),
+      );
+
+      final placeholder = find.byWidgetPredicate(
+        (widget) =>
+            widget is SizedBox && widget.width == 0 && widget.height == 24,
+      );
+      expect(placeholder, findsOneWidget);
+    });
+
+    testWidgets('未知の絵文字は最大幅を読み込み中の幅として使用する', (tester) async {
+      final pending = Completer<EmojiImage?>();
+      Future<EmojiImage?> resolver(String _) => pending.future;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmCustomEmoji(
+              name: 'unknown-size-limited',
+              resolver: resolver,
+              maxWidth: 70,
+            ),
+          ),
+        ),
+      );
+
+      final placeholder = find.byWidgetPredicate(
+        (widget) =>
+            widget is SizedBox && widget.width == 70 && widget.height == 24,
+      );
+      expect(placeholder, findsOneWidget);
+    });
+
+    testWidgets('既知のアスペクト比を初回の読み込み表示に反映する', (tester) async {
+      final pending = Completer<EmojiImage?>();
+      Future<EmojiImage?> resolver(String _) => pending.future;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmCustomEmoji(
+              name: 'known-size',
+              resolver: resolver,
+              aspectRatio: 4,
+            ),
+          ),
+        ),
+      );
+
+      final placeholder = find.byWidgetPredicate(
+        (widget) =>
+            widget is SizedBox && widget.width == 96 && widget.height == 24,
+      );
+      expect(placeholder, findsOneWidget);
+    });
+
+    testWidgets('判明済みのアスペクト比をState再生成時に再利用する', (tester) async {
+      final image = EmojiImage(
+        url: Uri.parse('https://example.com/cached-ratio.png'),
+        animated: false,
+        isSensitive: false,
+      );
+      final pending = Completer<EmojiImage?>();
+      var resolveCount = 0;
+      Future<EmojiImage?> resolver(String _) {
+        resolveCount++;
+        return resolveCount == 1 ? Future.value(image) : pending.future;
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MfmCustomEmoji(
+            name: 'cached-ratio',
+            resolver: resolver,
+            aspectRatio: 4,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MfmCustomEmoji(
+            name: 'cached-ratio',
+            resolver: resolver,
+          ),
+        ),
+      );
+
+      final placeholder = find.byWidgetPredicate(
+        (widget) =>
+            widget is SizedBox && widget.width == 96 && widget.height == 24,
+      );
+      expect(placeholder, findsOneWidget);
     });
 
     testWidgets('親が再ビルドされても同じ絵文字を再解決しない', (tester) async {


### PR DESCRIPTION
## 概要

Closes #12

#5 でカスタム絵文字を高さ固定・自然幅へ変更した後も、読み込み中のプレースホルダーが正方形の幅を確保していたため、画像表示時に本文がリフローする問題を修正します。

## 変更内容

- 未知サイズのプレースホルダーから正方形の幅指定を撤廃
  - `maxWidth` 指定時はその幅を使用
  - 未指定時は幅 0、高さのみを確保
- 画像 URL 単位の上限付き LRU アスペクト比キャッシュを追加
- resolver・絵文字名と直近 URL の対応を保持し、State 再生成直後から既知幅を復元
- 初回ロード前から比率が既知の場合に指定できる `aspectRatio` を追加
- `CachedNetworkImage` と同一のリサイズ済み provider を観測し、#5 の `memCacheHeight` を維持
- 回帰テストおよび README / CHANGELOG を更新

## 検証

- `fvm flutter test test/unit/mfm_custom_emoji_test.dart`（14件成功）
- Isar ネイティブ依存テストを除くテストスイート（230件成功）
- `fvm flutter analyze`（問題なし）

全テスト実行では既存の `emoji_config_test` 2件が失敗しますが、今回の変更に関係する失敗ではありません。

なお当初「実行環境に `libisar.dylib` がないため」と記載していましたが、その後の調査で原因の説明として不正確であることが判明したため追記します。実際には以下の2つの原因が独立して存在します。

- `MfmEmojiConfig.quickSetup` / `createDefault` が実際に `Isar.open` を呼ぶため、FFI 経由で `libisar.dylib` を要求します。この実体は `isar_community_flutter_libs` が CocoaPods の `vendored_libraries` として配布しており、Xcode でアプリをビルドしたときにのみバンドルされます。`flutter test` は Xcode ビルドを行わず素の Dart VM でヘッドレス実行するため、プラグインのネイティブコードは一切ロードされません。環境に置き忘れたのではなく、この実行形態では原理的に dylib が存在しません
- 仮に dylib を配置しても、2件のテストが同一の `serverUrl`（`https://example.com`）を使うため Isar のインスタンス名が衝突します。`Isar` はインスタンスを name のみで管理し directory を参照せず、かつ各テストが `close()` していないため、後続テストが `IsarError: Instance has already been opened.` で失敗します

したがって dylib を配置するだけでは解消せず、ユニットテストから実 DB を開いている設計側の見直しが必要です。

詳細な原因調査と対応方針: #14
