### PR TITLE
fix: 絵文字設定のIsarライフサイクルを管理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `MfmEmojiConfig.quickSetup()` / `createDefault()` が返す設定に、永続ストアを解放する `dispose()` を追加
+- `emojiStoreFactory` による絵文字ストアの注入に対応
+
+### Fixed
+- `emoji_config_test` がユニットテスト内で実Isarを開き、ネイティブライブラリ不在やインスタンス名衝突で失敗する問題を修正
+
 ## 0.3.0 - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,7 +134,16 @@ MfmText(
   text: ':custom_emoji: **Hello** World!',
   config: config,
 )
+
+// Later, release resources when the owner is disposed.
+await config.dispose();
 ```
+
+`quickSetup` and `createDefault` return an `MfmEmojiConfigHandle`, which can be
+used anywhere an `MfmRenderConfig` is accepted. The handle owns its persistent
+store and must be disposed. Unit tests can pass `emojiStoreFactory` to inject a
+test double without loading Isar's native library. Configurations created with
+`copyWith` share the same lifecycle; disposing any copy disposes them all.
 
 For advanced customization, see
 [Advanced Custom Emoji Configuration](#advanced-custom-emoji-configuration).
@@ -229,7 +238,7 @@ final isar = await openEmojiIsarForServer(baseUrl, directory: dir.path);
 // Create persistent catalog and resolver
 final catalog = PersistentEmojiCatalog(
   api: emojiApi,
-  store: IsarEmojiStore(isar),
+  store: IsarEmojiStore(isar, ownsIsar: true),
   meta: MetaClient(httpClient),
 );
 final resolver = MisskeyEmojiResolver(catalog);
@@ -260,7 +269,14 @@ MfmText(
 )
 ```
 
-#### 4. (Optional) Customize Fallback Display
+#### 4. Release Resources
+
+```dart
+emojiRefreshNotifier.dispose();
+await catalog.dispose();
+```
+
+#### 5. (Optional) Customize Fallback Display
 
 ```dart
 MfmCustomEmoji(
@@ -539,7 +555,17 @@ MfmText(
   text: ':custom_emoji: **こんにちは**',
   config: config,
 )
+
+// 後で、所有元の破棄時にリソースを解放
+await config.dispose();
 ```
+
+`quickSetup` と `createDefault` は、`MfmRenderConfig` としてそのまま使える
+`MfmEmojiConfigHandle` を返します。このハンドルは永続ストアを所有するため、
+不要になったら `dispose()` を呼んでください。ユニットテストでは
+`emojiStoreFactory` にテストダブルを注入すると、Isarのネイティブライブラリを
+ロードせずに構成処理を検証できます。`copyWith` で作成した設定は同じ
+ライフサイクルを共有し、いずれかを破棄するとすべて破棄済みになります。
 
 より詳細な制御が必要な場合は、
 [高度なカスタム絵文字の設定](#高度なカスタム絵文字の設定) を参照してください。
@@ -634,7 +660,7 @@ final isar = await openEmojiIsarForServer(baseUrl, directory: dir.path);
 // 永続化カタログとリゾルバーを作成
 final catalog = PersistentEmojiCatalog(
   api: emojiApi,
-  store: IsarEmojiStore(isar),
+  store: IsarEmojiStore(isar, ownsIsar: true),
   meta: MetaClient(httpClient),
 );
 final resolver = MisskeyEmojiResolver(catalog);
@@ -665,7 +691,14 @@ MfmText(
 )
 ```
 
-#### 4. (任意) フォールバック表示のカスタマイズ
+#### 4. リソースの解放
+
+```dart
+emojiRefreshNotifier.dispose();
+await catalog.dispose();
+```
+
+#### 5. (任意) フォールバック表示のカスタマイズ
 
 ```dart
 MfmCustomEmoji(

--- a/example/lib/core/emoji/emoji_service.dart
+++ b/example/lib/core/emoji/emoji_service.dart
@@ -7,14 +7,15 @@ class EmojiService {
   static const String _misskeyIoUrl = 'https://misskey.io';
   static final EmojiService instance = EmojiService._();
 
-  MfmRenderConfig? _config;
-  Future<MfmRenderConfig>? _initFuture;
+  MfmEmojiConfigHandle? _config;
+  Future<MfmEmojiConfigHandle>? _initFuture;
+  Future<void>? _disposeFuture;
 
   /// 初期化済みかどうか
   bool get isInitialized => _config != null;
 
   /// 共有用のMFM設定を取得（初期化前に呼ぶとエラー）
-  MfmRenderConfig get config {
+  MfmEmojiConfigHandle get config {
     final config = _config;
     if (config == null) {
       throw StateError(
@@ -25,7 +26,12 @@ class EmojiService {
   }
 
   /// サービスを初期化（複数回呼んでも安全）
-  Future<MfmRenderConfig> initialize() async {
+  Future<MfmEmojiConfigHandle> initialize() async {
+    final disposeFuture = _disposeFuture;
+    if (disposeFuture != null) {
+      await disposeFuture;
+    }
+
     if (_config != null) return _config!;
     if (_initFuture != null) return _initFuture!;
 
@@ -37,6 +43,20 @@ class EmojiService {
       return _config!;
     } finally {
       _initFuture = null;
+    }
+  }
+
+  /// 永続ストアなど、絵文字設定が所有するリソースを解放
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    final pending = _initFuture;
+    try {
+      final config = _config ?? (pending == null ? null : await pending);
+      _config = null;
+      await config?.dispose();
+    } finally {
+      _disposeFuture = null;
     }
   }
 }

--- a/lib/src/helpers/emoji_config.dart
+++ b/lib/src/helpers/emoji_config.dart
@@ -9,6 +9,140 @@ import 'package:path_provider/path_provider.dart';
 import '../config/mfm_render_config.dart';
 import '../widgets/mfm_custom_emoji.dart';
 
+/// カスタム絵文字の永続ストアを生成するファクトリー
+///
+/// 返したストアの所有権は[MfmEmojiConfigHandle]へ移り、
+/// [MfmEmojiConfigHandle.dispose]で破棄される。
+typedef MfmEmojiStoreFactory =
+    FutureOr<EmojiStore> Function({
+      required Uri serverUrl,
+      required String directory,
+    });
+
+/// 永続ストアのライフサイクルを所有するMFMレンダリング設定
+///
+/// [MfmRenderConfig]としてそのまま利用できる。
+/// 不要になったら[dispose]を呼び、Isarなどのリソースを解放すること。
+class MfmEmojiConfigHandle extends MfmRenderConfig {
+  MfmEmojiConfigHandle._({
+    required MfmRenderConfig config,
+    required _MfmEmojiConfigLifecycle lifecycle,
+  }) : _lifecycle = lifecycle,
+       super(
+         baseTextStyle: config.baseTextStyle,
+         enableAdvancedMfm: config.enableAdvancedMfm,
+         enableAnimation: config.enableAnimation,
+         enableNyaize: config.enableNyaize,
+         emojiBuilder: config.emojiBuilder,
+         unicodeEmojiBuilder: config.unicodeEmojiBuilder,
+         onLinkTap: config.onLinkTap,
+         onMentionTap: config.onMentionTap,
+         onHashtagTap: config.onHashtagTap,
+         onSearchTap: config.onSearchTap,
+         onClickableEvent: config.onClickableEvent,
+         fontFamilyResolver: config.fontFamilyResolver,
+         codeTheme: config.codeTheme,
+         codeDarkTheme: config.codeDarkTheme,
+         brightness: config.brightness,
+         showCodeBlockCopyButton: config.showCodeBlockCopyButton,
+         inlineCodeBgColorLight: config.inlineCodeBgColorLight,
+         inlineCodeBgColorDark: config.inlineCodeBgColorDark,
+       );
+
+  final _MfmEmojiConfigLifecycle _lifecycle;
+
+  /// この設定が破棄済み、または破棄中かどうか
+  bool get isDisposed => _lifecycle.isDisposed;
+
+  /// 自動同期の完了を待ち、永続ストアなどのリソースを解放する
+  ///
+  /// 複数回呼び出しても安全。
+  Future<void> dispose() => _lifecycle.dispose();
+
+  /// 設定値を変更しつつ、元のハンドルと同じリソース所有権を共有する。
+  ///
+  /// いずれかのコピーで[dispose]を呼ぶと、同じライフサイクルを共有する
+  /// すべてのコピーが破棄済みになる。
+  @override
+  MfmEmojiConfigHandle copyWith({
+    TextStyle? baseTextStyle,
+    bool? enableAdvancedMfm,
+    bool? enableAnimation,
+    bool? enableNyaize,
+    Widget Function(String name)? emojiBuilder,
+    Widget Function(String emoji)? unicodeEmojiBuilder,
+    void Function(String url)? onLinkTap,
+    void Function(String acct)? onMentionTap,
+    void Function(String tag)? onHashtagTap,
+    void Function(String query)? onSearchTap,
+    void Function(String eventId)? onClickableEvent,
+    String? Function(String fontType)? fontFamilyResolver,
+    Map<String, TextStyle>? codeTheme,
+    Map<String, TextStyle>? codeDarkTheme,
+    Brightness? brightness,
+    bool? showCodeBlockCopyButton,
+    Color? inlineCodeBgColorLight,
+    Color? inlineCodeBgColorDark,
+  }) {
+    final config = super.copyWith(
+      baseTextStyle: baseTextStyle,
+      enableAdvancedMfm: enableAdvancedMfm,
+      enableAnimation: enableAnimation,
+      enableNyaize: enableNyaize,
+      emojiBuilder: emojiBuilder,
+      unicodeEmojiBuilder: unicodeEmojiBuilder,
+      onLinkTap: onLinkTap,
+      onMentionTap: onMentionTap,
+      onHashtagTap: onHashtagTap,
+      onSearchTap: onSearchTap,
+      onClickableEvent: onClickableEvent,
+      fontFamilyResolver: fontFamilyResolver,
+      codeTheme: codeTheme,
+      codeDarkTheme: codeDarkTheme,
+      brightness: brightness,
+      showCodeBlockCopyButton: showCodeBlockCopyButton,
+      inlineCodeBgColorLight: inlineCodeBgColorLight,
+      inlineCodeBgColorDark: inlineCodeBgColorDark,
+    );
+    return MfmEmojiConfigHandle._(config: config, lifecycle: _lifecycle);
+  }
+}
+
+class _MfmEmojiConfigLifecycle {
+  _MfmEmojiConfigLifecycle({
+    required EmojiCatalog catalog,
+    required Future<void>? autoSyncFuture,
+    required ValueNotifier<int>? autoSyncNotifier,
+  }) : _catalog = catalog,
+       _autoSyncFuture = autoSyncFuture,
+       _autoSyncNotifier = autoSyncNotifier;
+
+  final EmojiCatalog _catalog;
+  final Future<void>? _autoSyncFuture;
+  final ValueNotifier<int>? _autoSyncNotifier;
+
+  Future<void>? _disposeFuture;
+
+  bool get isDisposed => _disposeFuture != null;
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    try {
+      try {
+        final autoSyncFuture = _autoSyncFuture;
+        if (autoSyncFuture != null) {
+          await autoSyncFuture;
+        }
+      } finally {
+        await _catalog.dispose();
+      }
+    } finally {
+      _autoSyncNotifier?.dispose();
+    }
+  }
+}
+
 /// MFMカスタム絵文字のセットアップを簡略化するヘルパークラス
 class MfmEmojiConfig {
   const MfmEmojiConfig._();
@@ -18,7 +152,8 @@ class MfmEmojiConfig {
   /// サーバーURLを指定するだけで永続化ストレージ込みのEmojiResolverとMfmRenderConfigを構築
   /// [emojiSize]は表示上の高さ、[emojiMaxWidth]は任意の最大幅として扱われる。
   /// [emojiRefreshListenable]が通知すると絵文字メタデータを再解決する。
-  static Future<MfmRenderConfig> quickSetup({
+  /// [emojiStoreFactory]を指定すると、Isarを開かずに任意のストアを利用できる。
+  static Future<MfmEmojiConfigHandle> quickSetup({
     required String serverUrl,
     String? storagePath,
     double emojiSize = 24.0,
@@ -27,6 +162,7 @@ class MfmEmojiConfig {
     Widget Function(BuildContext context, String name)? fallbackBuilder,
     SyncErrorCallback? onSyncError,
     bool autoSync = true,
+    MfmEmojiStoreFactory? emojiStoreFactory,
   }) {
     final uri = _normalizeServerUrl(serverUrl);
     return createDefault(
@@ -38,6 +174,7 @@ class MfmEmojiConfig {
       fallbackBuilder: fallbackBuilder,
       onSyncError: onSyncError,
       autoSync: autoSync,
+      emojiStoreFactory: emojiStoreFactory,
     );
   }
 
@@ -46,7 +183,8 @@ class MfmEmojiConfig {
   /// より詳細な制御が必要な場合に使用
   /// [emojiSize]は表示上の高さ、[emojiMaxWidth]は任意の最大幅として扱われる。
   /// [emojiRefreshListenable]が通知すると絵文字メタデータを再解決する。
-  static Future<MfmRenderConfig> createDefault({
+  /// [emojiStoreFactory]を指定すると、Isarを開かずに任意のストアを利用できる。
+  static Future<MfmEmojiConfigHandle> createDefault({
     required Uri serverUrl,
     String? storagePath,
     double emojiSize = 24.0,
@@ -55,6 +193,7 @@ class MfmEmojiConfig {
     Widget Function(BuildContext context, String name)? fallbackBuilder,
     SyncErrorCallback? onSyncError,
     bool autoSync = true,
+    MfmEmojiStoreFactory? emojiStoreFactory,
   }) async {
     final directory = (storagePath != null && storagePath.isNotEmpty)
         ? storagePath
@@ -62,8 +201,8 @@ class MfmEmojiConfig {
 
     await Directory(directory).create(recursive: true);
 
-    final isar = await openEmojiIsarForServer(
-      serverUrl,
+    final store = await (emojiStoreFactory ?? _createDefaultStore)(
+      serverUrl: serverUrl,
       directory: directory,
     );
 
@@ -71,7 +210,6 @@ class MfmEmojiConfig {
       config: MisskeyApiConfig(baseUrl: serverUrl),
     );
     final api = MisskeyEmojiApi(httpClient);
-    final store = IsarEmojiStore(isar);
 
     final catalog = PersistentEmojiCatalog(
       api: api,
@@ -82,30 +220,41 @@ class MfmEmojiConfig {
     final resolver = MisskeyEmojiResolver(catalog);
 
     var effectiveRefreshListenable = emojiRefreshListenable;
+    ValueNotifier<int>? autoSyncNotifier;
+    Future<void>? autoSyncFuture;
 
     if (autoSync) {
-      final autoSyncNotifier = ValueNotifier(0);
+      autoSyncNotifier = ValueNotifier(0);
       effectiveRefreshListenable = emojiRefreshListenable == null
           ? autoSyncNotifier
           : Listenable.merge([emojiRefreshListenable, autoSyncNotifier]);
-      unawaited(
-        catalog
-            .sync()
-            .catchError((Object error, StackTrace stackTrace) {
-              if (error is Exception) {
-                onSyncError?.call(error, stackTrace);
-              }
-            })
-            .whenComplete(() => autoSyncNotifier.value++),
-      );
+      autoSyncFuture = catalog
+          .sync()
+          .catchError((Object error, StackTrace stackTrace) {
+            if (error is Exception) {
+              onSyncError?.call(error, stackTrace);
+            }
+          })
+          .whenComplete(() => autoSyncNotifier!.value++);
+      unawaited(autoSyncFuture);
     }
 
-    return fromResolver(
-      resolver: resolver.call,
-      emojiSize: emojiSize,
-      emojiMaxWidth: emojiMaxWidth,
-      emojiRefreshListenable: effectiveRefreshListenable,
-      fallbackBuilder: fallbackBuilder,
+    final config = MfmRenderConfig(
+      emojiBuilder: _createEmojiBuilder(
+        resolver: resolver.call,
+        emojiSize: emojiSize,
+        emojiMaxWidth: emojiMaxWidth,
+        emojiRefreshListenable: effectiveRefreshListenable,
+        fallbackBuilder: fallbackBuilder,
+      ),
+    );
+    return MfmEmojiConfigHandle._(
+      config: config,
+      lifecycle: _MfmEmojiConfigLifecycle(
+        catalog: catalog,
+        autoSyncFuture: autoSyncFuture,
+        autoSyncNotifier: autoSyncNotifier,
+      ),
     );
   }
 
@@ -121,15 +270,43 @@ class MfmEmojiConfig {
     Widget Function(BuildContext context, String name)? fallbackBuilder,
   }) {
     return MfmRenderConfig(
-      emojiBuilder: (name) => MfmCustomEmoji(
-        name: name,
+      emojiBuilder: _createEmojiBuilder(
         resolver: resolver,
-        size: emojiSize,
-        maxWidth: emojiMaxWidth,
-        refreshListenable: emojiRefreshListenable,
+        emojiSize: emojiSize,
+        emojiMaxWidth: emojiMaxWidth,
+        emojiRefreshListenable: emojiRefreshListenable,
         fallbackBuilder: fallbackBuilder,
       ),
     );
+  }
+
+  static Widget Function(String name) _createEmojiBuilder({
+    required EmojiResolver resolver,
+    required double emojiSize,
+    required double? emojiMaxWidth,
+    required Listenable? emojiRefreshListenable,
+    required Widget Function(BuildContext context, String name)?
+    fallbackBuilder,
+  }) {
+    return (name) => MfmCustomEmoji(
+      name: name,
+      resolver: resolver,
+      size: emojiSize,
+      maxWidth: emojiMaxWidth,
+      refreshListenable: emojiRefreshListenable,
+      fallbackBuilder: fallbackBuilder,
+    );
+  }
+
+  static Future<EmojiStore> _createDefaultStore({
+    required Uri serverUrl,
+    required String directory,
+  }) async {
+    final isar = await openEmojiIsarForServer(
+      serverUrl,
+      directory: directory,
+    );
+    return IsarEmojiStore(isar, ownsIsar: true);
   }
 
   static Uri _normalizeServerUrl(String serverUrl) {

--- a/test/unit/emoji_config_test.dart
+++ b/test/unit/emoji_config_test.dart
@@ -36,21 +36,40 @@ void main() {
 
   test('quickSetup returns config with emojiBuilder', () async {
     final dir = await Directory.systemTemp.createTemp('mfm_emoji_quick');
+    final store = _FakeEmojiStore();
+    Uri? factoryServerUrl;
+    String? factoryDirectory;
     addTearDown(() async {
       await dir.delete(recursive: true);
     });
 
     final config = await MfmEmojiConfig.quickSetup(
-      serverUrl: 'https://example.com',
+      serverUrl: 'example.com',
       storagePath: dir.path,
       autoSync: false,
+      emojiStoreFactory: ({required Uri serverUrl, required String directory}) {
+        factoryServerUrl = serverUrl;
+        factoryDirectory = directory;
+        return store;
+      },
     );
+    addTearDown(config.dispose);
 
+    expect(config, isA<MfmEmojiConfigHandle>());
     expect(config.emojiBuilder, isNotNull);
+    expect(factoryServerUrl, Uri.parse('https://example.com'));
+    expect(factoryDirectory, dir.path);
+
+    await config.dispose();
+    await config.dispose();
+
+    expect(config.isDisposed, isTrue);
+    expect(store.disposeCalls, 1);
   });
 
-  test('createDefault returns config with emojiBuilder', () async {
-    final dir = await Directory.systemTemp.createTemp('mfm_emoji_default');
+  test('copyWith preserves shared lifecycle ownership', () async {
+    final dir = await Directory.systemTemp.createTemp('mfm_emoji_copy');
+    final store = _FakeEmojiStore();
     addTearDown(() async {
       await dir.delete(recursive: true);
     });
@@ -59,8 +78,61 @@ void main() {
       serverUrl: Uri.parse('https://example.com'),
       storagePath: dir.path,
       autoSync: false,
+      emojiStoreFactory:
+          ({required Uri serverUrl, required String directory}) => store,
     );
+    addTearDown(config.dispose);
 
-    expect(config.emojiBuilder, isNotNull);
+    final copied = config.copyWith(enableAnimation: false);
+
+    expect(copied, isA<MfmEmojiConfigHandle>());
+    expect(copied.enableAnimation, isFalse);
+    expect(config.enableAnimation, isTrue);
+
+    await copied.dispose();
+    await config.dispose();
+
+    expect(copied.isDisposed, isTrue);
+    expect(config.isDisposed, isTrue);
+    expect(store.disposeCalls, 1);
   });
+
+  test('createDefault returns config with emojiBuilder', () async {
+    final dir = await Directory.systemTemp.createTemp('mfm_emoji_default');
+    final store = _FakeEmojiStore();
+    addTearDown(() async {
+      await dir.delete(recursive: true);
+    });
+
+    final config = await MfmEmojiConfig.createDefault(
+      serverUrl: Uri.parse('https://example.com'),
+      storagePath: dir.path,
+      autoSync: false,
+      emojiStoreFactory:
+          ({required Uri serverUrl, required String directory}) => store,
+    );
+    addTearDown(config.dispose);
+
+    expect(config, isA<MfmEmojiConfigHandle>());
+    expect(config.emojiBuilder, isNotNull);
+
+    await config.dispose();
+
+    expect(store.disposeCalls, 1);
+  });
+}
+
+class _FakeEmojiStore implements EmojiStore {
+  int disposeCalls = 0;
+
+  @override
+  Future<List<EmojiRecord>> loadAll() async => [];
+
+  @override
+  Future<void> saveAll(List<EmojiRecord> all) async {}
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+  }
 }


### PR DESCRIPTION
## 概要

emoji_config_test がユニットテスト内で実 Isar を開き、ネイティブライブラリ不在やインスタンス名衝突で失敗する問題を修正します。

## 変更内容

- emojiStoreFactory を追加し、ユニットテストから EmojiStore を注入可能に変更
- quickSetup / createDefault の戻り値に dispose 可能な MfmEmojiConfigHandle を導入
- IsarEmojiStore に Isar の所有権を持たせ、ハンドル破棄時に解放
- copyWith 後も同じライフサイクルを共有し、ストアを一度だけ破棄
- EmojiService の破棄中に再初期化されないよう同期
- README と CHANGELOG を更新

## 動作確認

- [x] flutter analyze
- [x] flutter test（233件成功）
- [x] git diff --check

Closes #14