### PR TITLE
chore: 0.4.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.4.0 - 2026-08-10
 
 ### Added
 - `MfmEmojiConfig.quickSetup()` / `createDefault()` が返す設定に、永続ストアを解放する `dispose()` を追加
 - `emojiStoreFactory` による絵文字ストアの注入に対応
 - カスタム絵文字の既知アスペクト比を指定する `aspectRatio` を追加
+
+### Changed
+- `MfmEmojiConfig.quickSetup()` / `createDefault()` の戻り値を `MfmRenderConfig` のサブクラスである `MfmEmojiConfigHandle` に変更
+  - `MfmRenderConfig` として扱う既存コードは変更不要
+  - `copyWith()` で作成した設定はライフサイクルを共有し、いずれかを破棄するとすべて破棄済みになる
 
 ### Fixed
 - `emoji_config_test` がユニットテスト内で実Isarを開き、ネイティブライブラリ不在やインスタンス名衝突で失敗する問題を修正

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.3.0
+  misskey_mfm_renderer: ^0.4.0
 ```
 
 ## Quick Start
@@ -211,7 +211,7 @@ If your project enforces direct dependencies for imported packages, add:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.3.0
+  misskey_mfm_renderer: ^0.4.0
   misskey_api_core: ^1.0.0
   path_provider: ^2.1.5
 ```
@@ -541,7 +541,7 @@ Misskeyの猫モードと同等の挙動で、テキストノードの文字列�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.3.0
+  misskey_mfm_renderer: ^0.4.0
 ```
 
 ## クイックスタート
@@ -636,7 +636,7 @@ import対象パッケージを直接依存に置きたい場合は追加して�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.3.0
+  misskey_mfm_renderer: ^0.4.0
   misskey_api_core: ^1.0.0
   path_provider: ^2.1.5
 ```

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: misskey_mfm_renderer
 description: Flutter widget renderer for Misskey MFM (Misskey Flavored Markdown)
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
 
 environment:


### PR DESCRIPTION
## Summary
- バージョンを 0.4.0 にバンプし、CHANGELOG の節を確定する
- リリース内容は #13（カスタム絵文字読み込み時のリフロー抑制）と #15（絵文字設定のIsarライフサイクル管理）の2件のバグ修正

## 変更内容
- `pubspec.yaml`: `version: 0.3.0` → `0.4.0`
- `CHANGELOG.md`: `## Unreleased` を `## 0.4.0 - 2026-08-10` として確定し、戻り値型の変更を `### Changed` として追記
- `README.md`: 依存関係の記載を `^0.3.0` → `^0.4.0` に更新
- `example/pubspec.lock`: 参照バージョンを追従

## 含まれる変更（v0.3.0 からの差分）
| PR | Issue | 種別 | 内容 |
|---|---|---|---|
| #13 | #12 | fix | 読み込み中プレースホルダーの正方形幅指定を撤廃し本文のリフローを抑制、アスペクト比の LRU キャッシュと `aspectRatio` を追加 |
| #15 | #14 | fix | `emojiStoreFactory` によるストア注入と `MfmEmojiConfigHandle` を導入し、ユニットテストが実 Isar を開かないよう修正 |

詳細は `CHANGELOG.md` の `## 0.4.0 - 2026-08-10` セクションを参照。

## SemVer 上の位置付け
- 2件とも修正内容自体は bugfix だが、修正手段として新規公開APIを追加しているため MINOR バンプ
  - 追加: `MfmEmojiConfigHandle`（`dispose()` / `isDisposed`）、`MfmEmojiStoreFactory` typedef、`MfmEmojiConfig.quickSetup` / `createDefault` の `emojiStoreFactory`、`MfmCustomEmoji.aspectRatio`
  - 変更: `quickSetup` / `createDefault` の戻り値型 `Future<MfmRenderConfig>` → `Future<MfmEmojiConfigHandle>`
- 戻り値型の変更は `MfmEmojiConfigHandle extends MfmRenderConfig` による共変な絞り込みのため、破壊的変更ではない
  - v0.3.0 時点の呼び出し形（`final MfmRenderConfig config = await MfmEmojiConfig.quickSetup(...)` 等）がそのままコンパイルできることを `flutter analyze` で確認済み
- 追加パラメータはすべて任意で、既定動作は従来どおり
- `IsarEmojiStore` の `ownsIsar` は misskey_emoji 1.0.0 に既存のため、依存バージョン制約の変更は不要

## 検証
- `fvm flutter analyze`: No issues found!
- `fvm flutter test`: 237件すべて成功
  - v0.3.0 時点で失敗していた `emoji_config_test` の2件は #15 により解消済み
- `fvm flutter pub publish --dry-run`: Package has 0 warnings.（アーカイブ 131 KB）
