### PR TITLE
chore: 0.5.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.5.0 - 2026-08-10
 
 ### Added
 - カスタム絵文字のURL・アスペクト比キャッシュを安定した識別子で分離する `cacheScope` を追加

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.4.0
+  misskey_mfm_renderer: ^0.5.0
 ```
 
 ## Quick Start
@@ -220,7 +220,7 @@ If your project enforces direct dependencies for imported packages, add:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.4.0
+  misskey_mfm_renderer: ^0.5.0
   misskey_api_core: ^1.0.0
   path_provider: ^2.1.5
 ```
@@ -561,7 +561,7 @@ scopeはレイアウトヒントのキャッシュだけを制御し、resolver�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.4.0
+  misskey_mfm_renderer: ^0.5.0
 ```
 
 ## クイックスタート
@@ -656,7 +656,7 @@ import対象パッケージを直接依存に置きたい場合は追加して�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.4.0
+  misskey_mfm_renderer: ^0.5.0
   misskey_api_core: ^1.0.0
   path_provider: ^2.1.5
 ```

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: misskey_mfm_renderer
 description: Flutter widget renderer for Misskey MFM (Misskey Flavored Markdown)
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
 
 environment:


### PR DESCRIPTION
## Summary

- バージョンを 0.5.0 にバンプし、CHANGELOG の節を確定する
- リリース内容は #19（カスタム絵文字のリフロー抑制安定化）

## 変更内容

- `pubspec.yaml`: `version: 0.4.0` → `0.5.0`
- `CHANGELOG.md`: `## Unreleased` を `## 0.5.0 - 2026-08-10` として確定
- `README.md`: 依存関係の記載を `^0.4.0` → `^0.5.0` に更新
- `example/pubspec.lock`: 参照バージョンを追従

## 含まれる変更（v0.4.0 からの差分）

| PR | Issue | 種別 | 内容 |
|---|---|---|---|
| #19 | #18 | fix | resolverクロージャ再生成時のアスペクト比再利用を安定化する `cacheScope` を追加し、未知幅プレースホルダと `maxWidth` による逆方向リフローを修正 |

詳細は `CHANGELOG.md` の `## 0.5.0 - 2026-08-10` セクションを参照。

## SemVer 上の位置付け

- バグ修正に加えて新しい公開API `MfmCustomEmoji.cacheScope` を追加するため MINOR バンプ
- `cacheScope` は任意パラメータであり、未指定時はresolver関数オブジェクトを使用するため既存コードの変更は不要
- `MfmEmojiConfig` は安定したscopeを自動設定

## 初回ロードについて

- アスペクト比が真に未知の場合は幅0から自然幅へ変化するため、初回リフローは仕様として残る
- 正確な初期幅が必要な場合は既存の `aspectRatio` を指定する
- この制約はREADMEに明記済み

## 検証

- `fvm flutter analyze`: No issues found!
- `fvm flutter test`: 243件すべて成功
- `fvm flutter pub publish --dry-run`: Package has 0 warnings.（アーカイブ 133 KB）
