### PR TITLE
絵文字設定を misskey_client へ移行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Breaking:** `MfmEmojiConfig.quickSetup()` / `createDefault()` で、呼び出し元が所有する `MisskeyClient` を必須化
+- **Breaking:** `MfmEmojiConfig.createDefault()` で、呼び出し元が所有する `MisskeyClient` を必須化
   - 絵文字取得専用のHTTPクライアント生成を廃止し、アプリの接続設定・認証情報を再利用
-  - `MisskeyClient` の公開APIからベースURLを取得できないため、サーバー別ストアの識別用として `serverUrl` は引き続き指定
   - `MfmEmojiConfigHandle.dispose()` はカタログとストアのみを破棄し、渡された `MisskeyClient` は破棄しない
 - `misskey_api_core` への依存を廃止し、`misskey_client` と `misskey_emoji` 2.0の `EmojiSource` APIへ移行
+
+### Removed
+- **Breaking:** `MfmEmojiConfig.quickSetup()` / `createDefault()` から `serverUrl` 引数を削除
+  - `misskey_client` 1.0.0-beta.6 で追加された `MisskeyClient.baseUrl` から導出するようになったため
+  - 従来は `client` と `serverUrl` の両方を要求しており、食い違う値を渡せてしまう問題があった
+
+- **Breaking:** `MfmEmojiConfig.quickSetup()` を削除。`serverUrl` の廃止により `createDefault()` と同一シグネチャになったため。`createDefault()` を使用すること
 
 ## 0.5.0 - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Breaking:** `MfmEmojiConfig.quickSetup()` / `createDefault()` で、呼び出し元が所有する `MisskeyClient` を必須化
+  - 絵文字取得専用のHTTPクライアント生成を廃止し、アプリの接続設定・認証情報を再利用
+  - `MisskeyClient` の公開APIからベースURLを取得できないため、サーバー別ストアの識別用として `serverUrl` は引き続き指定
+  - `MfmEmojiConfigHandle.dispose()` はカタログとストアのみを破棄し、渡された `MisskeyClient` は破棄しない
+- `misskey_api_core` への依存を廃止し、`misskey_client` と `misskey_emoji` 2.0の `EmojiSource` APIへ移行
+
 ## 0.5.0 - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Add the dependency to your `pubspec.yaml`:
 ```yaml
 dependencies:
   misskey_mfm_renderer: ^0.5.0
+  misskey_client: ^1.0.0-beta.5
 ```
 
 ## Quick Start
@@ -134,11 +135,18 @@ dependencies:
 For most use cases, use the helper function to quickly set up emoji support:
 
 ```dart
+import 'package:misskey_client/misskey_client.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+final serverUrl = Uri.parse('https://misskey.io');
+final client = MisskeyClient(
+  config: MisskeyClientConfig(baseUrl: serverUrl),
+);
 
 // One-time setup (e.g., in main())
 final config = await MfmEmojiConfig.quickSetup(
-  serverUrl: 'https://misskey.io',
+  client: client,
+  serverUrl: serverUrl.toString(),
 );
 
 // Use anywhere in your app
@@ -156,6 +164,9 @@ used anywhere an `MfmRenderConfig` is accepted. The handle owns its persistent
 store and must be disposed. Unit tests can pass `emojiStoreFactory` to inject a
 test double without loading Isar's native library. Configurations created with
 `copyWith` share the same lifecycle; disposing any copy disposes them all.
+The provided `MisskeyClient` remains owned by the application and is not
+disposed with the handle. `serverUrl` is also required only to partition the
+persistent emoji store because `MisskeyClient` does not expose its base URL.
 
 For advanced customization, see
 [Advanced Custom Emoji Configuration](#advanced-custom-emoji-configuration).
@@ -221,7 +232,8 @@ If your project enforces direct dependencies for imported packages, add:
 ```yaml
 dependencies:
   misskey_mfm_renderer: ^0.5.0
-  misskey_api_core: ^1.0.0
+  misskey_client: ^1.0.0-beta.5
+  misskey_emoji: ^2.0.0-beta.1
   path_provider: ^2.1.5
 ```
 
@@ -229,19 +241,19 @@ dependencies:
 
 ```dart
 import 'package:flutter/foundation.dart';
-import 'package:misskey_api_core/misskey_api_core.dart';
+import 'package:misskey_client/misskey_client.dart';
 import 'package:misskey_emoji/misskey_emoji.dart';
 import 'package:path_provider/path_provider.dart';
 
 final baseUrl = Uri.parse('https://misskey.io');
 
-// Create HTTP client for Misskey API
-final httpClient = MisskeyHttpClient(
-  config: MisskeyApiConfig(baseUrl: baseUrl),
+// Reuse the application's Misskey client
+final client = MisskeyClient(
+  config: MisskeyClientConfig(baseUrl: baseUrl),
 );
 
-// Create emoji API client
-final emojiApi = MisskeyEmojiApi(httpClient);
+// Create an emoji source backed by the Misskey client
+final emojiSource = MisskeyClientEmojiSource(client);
 
 // Open Isar for emoji metadata storage
 final dir = await getApplicationDocumentsDirectory();
@@ -249,9 +261,8 @@ final isar = await openEmojiIsarForServer(baseUrl, directory: dir.path);
 
 // Create persistent catalog and resolver
 final catalog = PersistentEmojiCatalog(
-  api: emojiApi,
+  source: emojiSource,
   store: IsarEmojiStore(isar, ownsIsar: true),
-  meta: MetaClient(httpClient),
 );
 final resolver = MisskeyEmojiResolver(catalog);
 final emojiRefreshNotifier = ValueNotifier(0);
@@ -562,6 +573,7 @@ scopeはレイアウトヒントのキャッシュだけを制御し、resolver�
 ```yaml
 dependencies:
   misskey_mfm_renderer: ^0.5.0
+  misskey_client: ^1.0.0-beta.5
 ```
 
 ## クイックスタート
@@ -569,11 +581,18 @@ dependencies:
 多くのケースでは、ヘルパー関数で簡単に絵文字対応を設定できます：
 
 ```dart
+import 'package:misskey_client/misskey_client.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+final serverUrl = Uri.parse('https://misskey.io');
+final client = MisskeyClient(
+  config: MisskeyClientConfig(baseUrl: serverUrl),
+);
 
 // 1回だけ初期化（例: main()）
 final config = await MfmEmojiConfig.quickSetup(
-  serverUrl: 'https://misskey.io',
+  client: client,
+  serverUrl: serverUrl.toString(),
 );
 
 // アプリ内のどこでも利用可能
@@ -592,6 +611,9 @@ await config.dispose();
 `emojiStoreFactory` にテストダブルを注入すると、Isarのネイティブライブラリを
 ロードせずに構成処理を検証できます。`copyWith` で作成した設定は同じ
 ライフサイクルを共有し、いずれかを破棄するとすべて破棄済みになります。
+渡した `MisskeyClient` の所有権はアプリ側に残り、ハンドルと一緒には破棄されません。
+`MisskeyClient` はベースURLを公開していないため、`serverUrl` は永続絵文字ストアを
+サーバーごとに分離する目的にのみ、併せて指定します。
 
 より詳細な制御が必要な場合は、
 [高度なカスタム絵文字の設定](#高度なカスタム絵文字の設定) を参照してください。
@@ -657,7 +679,8 @@ import対象パッケージを直接依存に置きたい場合は追加して�
 ```yaml
 dependencies:
   misskey_mfm_renderer: ^0.5.0
-  misskey_api_core: ^1.0.0
+  misskey_client: ^1.0.0-beta.5
+  misskey_emoji: ^2.0.0-beta.1
   path_provider: ^2.1.5
 ```
 
@@ -665,19 +688,19 @@ dependencies:
 
 ```dart
 import 'package:flutter/foundation.dart';
-import 'package:misskey_api_core/misskey_api_core.dart';
+import 'package:misskey_client/misskey_client.dart';
 import 'package:misskey_emoji/misskey_emoji.dart';
 import 'package:path_provider/path_provider.dart';
 
 final baseUrl = Uri.parse('https://misskey.io');
 
-// Misskey API用のHTTPクライアントを作成
-final httpClient = MisskeyHttpClient(
-  config: MisskeyApiConfig(baseUrl: baseUrl),
+// アプリのMisskeyクライアントを再利用
+final client = MisskeyClient(
+  config: MisskeyClientConfig(baseUrl: baseUrl),
 );
 
-// 絵文字APIクライアントを作成
-final emojiApi = MisskeyEmojiApi(httpClient);
+// Misskeyクライアントを使用する絵文字ソースを作成
+final emojiSource = MisskeyClientEmojiSource(client);
 
 // 絵文字メタデータ保存用のIsarをオープン
 final dir = await getApplicationDocumentsDirectory();
@@ -685,9 +708,8 @@ final isar = await openEmojiIsarForServer(baseUrl, directory: dir.path);
 
 // 永続化カタログとリゾルバーを作成
 final catalog = PersistentEmojiCatalog(
-  api: emojiApi,
+  source: emojiSource,
   store: IsarEmojiStore(isar, ownsIsar: true),
-  meta: MetaClient(httpClient),
 );
 final resolver = MisskeyEmojiResolver(catalog);
 final emojiRefreshNotifier = ValueNotifier(0);

--- a/README.md
+++ b/README.md
@@ -144,10 +144,7 @@ final client = MisskeyClient(
 );
 
 // One-time setup (e.g., in main())
-final config = await MfmEmojiConfig.quickSetup(
-  client: client,
-  serverUrl: serverUrl.toString(),
-);
+final config = await MfmEmojiConfig.createDefault(client: client);
 
 // Use anywhere in your app
 MfmText(
@@ -159,14 +156,14 @@ MfmText(
 await config.dispose();
 ```
 
-`quickSetup` and `createDefault` return an `MfmEmojiConfigHandle`, which can be
+`createDefault` returns an `MfmEmojiConfigHandle`, which can be
 used anywhere an `MfmRenderConfig` is accepted. The handle owns its persistent
 store and must be disposed. Unit tests can pass `emojiStoreFactory` to inject a
 test double without loading Isar's native library. Configurations created with
 `copyWith` share the same lifecycle; disposing any copy disposes them all.
 The provided `MisskeyClient` remains owned by the application and is not
-disposed with the handle. `serverUrl` is also required only to partition the
-persistent emoji store because `MisskeyClient` does not expose its base URL.
+disposed with the handle. The persistent emoji store is partitioned per server
+using `MisskeyClient.baseUrl`, so no separate server URL argument is needed.
 
 For advanced customization, see
 [Advanced Custom Emoji Configuration](#advanced-custom-emoji-configuration).
@@ -590,10 +587,7 @@ final client = MisskeyClient(
 );
 
 // 1回だけ初期化（例: main()）
-final config = await MfmEmojiConfig.quickSetup(
-  client: client,
-  serverUrl: serverUrl.toString(),
-);
+final config = await MfmEmojiConfig.createDefault(client: client);
 
 // アプリ内のどこでも利用可能
 MfmText(
@@ -605,15 +599,15 @@ MfmText(
 await config.dispose();
 ```
 
-`quickSetup` と `createDefault` は、`MfmRenderConfig` としてそのまま使える
+`createDefault` は、`MfmRenderConfig` としてそのまま使える
 `MfmEmojiConfigHandle` を返します。このハンドルは永続ストアを所有するため、
 不要になったら `dispose()` を呼んでください。ユニットテストでは
 `emojiStoreFactory` にテストダブルを注入すると、Isarのネイティブライブラリを
 ロードせずに構成処理を検証できます。`copyWith` で作成した設定は同じ
 ライフサイクルを共有し、いずれかを破棄するとすべて破棄済みになります。
 渡した `MisskeyClient` の所有権はアプリ側に残り、ハンドルと一緒には破棄されません。
-`MisskeyClient` はベースURLを公開していないため、`serverUrl` は永続絵文字ストアを
-サーバーごとに分離する目的にのみ、併せて指定します。
+永続絵文字ストアは `MisskeyClient.baseUrl` を用いてサーバーごとに分離されるため、
+サーバーURLを別途指定する必要はありません。
 
 より詳細な制御が必要な場合は、
 [高度なカスタム絵文字の設定](#高度なカスタム絵文字の設定) を参照してください。

--- a/example/lib/core/emoji/emoji_service.dart
+++ b/example/lib/core/emoji/emoji_service.dart
@@ -43,10 +43,8 @@ class EmojiService {
     final client = _client ??= MisskeyClient(
       config: MisskeyClientConfig(baseUrl: Uri.parse(_misskeyIoUrl)),
     );
-    _initFuture = MfmEmojiConfig.quickSetup(
-      client: client,
-      serverUrl: _misskeyIoUrl,
-    );
+    // 接続先は client から導出されるため serverUrl の指定は不要
+    _initFuture = MfmEmojiConfig.createDefault(client: client);
     try {
       _config = await _initFuture;
       return _config!;

--- a/example/lib/core/emoji/emoji_service.dart
+++ b/example/lib/core/emoji/emoji_service.dart
@@ -1,3 +1,4 @@
+import 'package:misskey_client/misskey_client.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
 
 /// Misskey.ioの絵文字設定を管理するシングルトンサービス
@@ -7,6 +8,10 @@ class EmojiService {
   static const String _misskeyIoUrl = 'https://misskey.io';
   static final EmojiService instance = EmojiService._();
 
+  /// 絵文字取得に使うAPIクライアント
+  ///
+  /// 所有権はこのサービスにあり、[MfmEmojiConfigHandle.dispose]では破棄されない
+  MisskeyClient? _client;
   MfmEmojiConfigHandle? _config;
   Future<MfmEmojiConfigHandle>? _initFuture;
   Future<void>? _disposeFuture;
@@ -35,7 +40,11 @@ class EmojiService {
     if (_config != null) return _config!;
     if (_initFuture != null) return _initFuture!;
 
+    final client = _client ??= MisskeyClient(
+      config: MisskeyClientConfig(baseUrl: Uri.parse(_misskeyIoUrl)),
+    );
     _initFuture = MfmEmojiConfig.quickSetup(
+      client: client,
       serverUrl: _misskeyIoUrl,
     );
     try {
@@ -55,6 +64,8 @@ class EmojiService {
       final config = _config ?? (pending == null ? null : await pending);
       _config = null;
       await config?.dispose();
+      // MisskeyClientの所有権はこのサービスにあるため、ここで破棄する
+      _client = null;
     } finally {
       _disposeFuture = null;
     }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: b9d46faecab38fc8cc286f80bc4d61a3bb5d4ac49e51ed877b4d6706efe57b25
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.1"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -220,18 +220,18 @@ packages:
     dependency: transitive
     description:
       name: isar_community
-      sha256: d92315e1862448f236489c2b2b1f9a7ad5ba2405f42d87216234be4fb2e1dd2d
+      sha256: "683fd093956eac3a660776afb70d65d50a3391b3587b40b89e3d12586b8cc47f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.2"
   isar_community_flutter_libs:
     dependency: transitive
     description:
       name: isar_community_flutter_libs
-      sha256: "3c072d8d77e820196fa23839b88481c50d903c73b3c0db6e647b29509d04fe3b"
+      sha256: c44340fa38c81ef16d924202d443bbe799cde4826be9a31a9dc92ee612e1966f
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.2"
   js:
     dependency: transitive
     description:
@@ -244,10 +244,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -284,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.2"
+    version: "2.7.0"
   matcher:
     dependency: transitive
     description:
@@ -320,21 +320,20 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  misskey_api_core:
-    dependency: transitive
+  misskey_client:
+    dependency: "direct main"
     description:
-      name: misskey_api_core
-      sha256: "32e17877e5e8044027b6815b510001d4329854d559269b405464e796a16b1ae5"
+      name: misskey_client
+      sha256: "469db5c2add672789c84fd41347ca94329260aff495a98e8003f201d08382177"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.0-beta.5"
   misskey_emoji:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: misskey_emoji
-      sha256: ed33718d9e06fcfc41a58991ac2e467ddd66a98b84db8365e3c7abf145fa0b33
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../misskey_emoji"
+      relative: true
+    source: path
     version: "1.0.0"
   misskey_mfm_parser:
     dependency: transitive
@@ -479,14 +478,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
-  rate_limiter:
-    dependency: transitive
-    description:
-      name: rate_limiter
-      sha256: "2bae2e961adedf7fc2e8b0305d30e3a3619baf001d050c6907870c5c6235b559"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   retry:
     dependency: transitive
     description:
@@ -660,22 +651,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  web_socket:
-    dependency: transitive
-    description:
-      name: web_socket
-      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
-  web_socket_channel:
-    dependency: transitive
-    description:
-      name: web_socket_channel
-      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -324,17 +324,18 @@ packages:
     dependency: "direct main"
     description:
       name: misskey_client
-      sha256: "469db5c2add672789c84fd41347ca94329260aff495a98e8003f201d08382177"
+      sha256: "5c9ec223f29f551462af42da7cbe70875245fe01684dbb0c81b35f9153feccc2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-beta.5"
+    version: "1.0.0-beta.6"
   misskey_emoji:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../misskey_emoji"
-      relative: true
-    source: path
-    version: "1.0.0"
+      name: misskey_emoji
+      sha256: "4abace668b9dd72d62cdc5cf6f24743589a7b853f478b3cdb3aa88ddf941b348"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0-beta.1"
   misskey_mfm_parser:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
   misskey_mfm_renderer:
     path: ../
 dev_dependencies:
@@ -22,6 +22,3 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-dependency_overrides:
-  misskey_emoji:
-    path: ../../misskey_emoji

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  misskey_client: ^1.0.0-beta.5
   misskey_mfm_renderer:
     path: ../
 dev_dependencies:
@@ -20,3 +21,7 @@ dev_dependencies:
   pubspec_dependency_sorter: ^1.0.5
 flutter:
   uses-material-design: true
+
+dependency_overrides:
+  misskey_emoji:
+    path: ../../misskey_emoji

--- a/lib/src/helpers/emoji_config.dart
+++ b/lib/src/helpers/emoji_config.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
-import 'package:misskey_api_core/misskey_api_core.dart';
+import 'package:misskey_client/misskey_client.dart';
 import 'package:misskey_emoji/misskey_emoji.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -149,11 +149,14 @@ class MfmEmojiConfig {
 
   /// シンプルなセットアップ（最も一般的な使用ケース）
   ///
-  /// サーバーURLを指定するだけで永続化ストレージ込みのEmojiResolverとMfmRenderConfigを構築
+  /// [client]を利用して永続化ストレージ込みのEmojiResolverとMfmRenderConfigを構築
+  /// [serverUrl]はサーバーごとに永続ストアを分離するために使用する。
+  /// [client]の所有権は呼び出し元にあり、返されたハンドルの破棄対象には含まれない。
   /// [emojiSize]は表示上の高さ、[emojiMaxWidth]は任意の最大幅として扱われる。
   /// [emojiRefreshListenable]が通知すると絵文字メタデータを再解決する。
   /// [emojiStoreFactory]を指定すると、Isarを開かずに任意のストアを利用できる。
   static Future<MfmEmojiConfigHandle> quickSetup({
+    required MisskeyClient client,
     required String serverUrl,
     String? storagePath,
     double emojiSize = 24.0,
@@ -166,6 +169,7 @@ class MfmEmojiConfig {
   }) {
     final uri = _normalizeServerUrl(serverUrl);
     return createDefault(
+      client: client,
       serverUrl: uri,
       storagePath: storagePath,
       emojiSize: emojiSize,
@@ -181,10 +185,13 @@ class MfmEmojiConfig {
   /// カスタマイズ可能なセットアップ
   ///
   /// より詳細な制御が必要な場合に使用
+  /// [serverUrl]はサーバーごとに永続ストアを分離するために使用する。
+  /// [client]の所有権は呼び出し元にあり、返されたハンドルの破棄対象には含まれない。
   /// [emojiSize]は表示上の高さ、[emojiMaxWidth]は任意の最大幅として扱われる。
   /// [emojiRefreshListenable]が通知すると絵文字メタデータを再解決する。
   /// [emojiStoreFactory]を指定すると、Isarを開かずに任意のストアを利用できる。
   static Future<MfmEmojiConfigHandle> createDefault({
+    required MisskeyClient client,
     required Uri serverUrl,
     String? storagePath,
     double emojiSize = 24.0,
@@ -206,15 +213,9 @@ class MfmEmojiConfig {
       directory: directory,
     );
 
-    final httpClient = MisskeyHttpClient(
-      config: MisskeyApiConfig(baseUrl: serverUrl),
-    );
-    final api = MisskeyEmojiApi(httpClient);
-
     final catalog = PersistentEmojiCatalog(
-      api: api,
+      source: MisskeyClientEmojiSource(client),
       store: store,
-      meta: MetaClient(httpClient),
       onSyncError: onSyncError,
     );
     final resolver = MisskeyEmojiResolver(catalog);

--- a/lib/src/helpers/emoji_config.dart
+++ b/lib/src/helpers/emoji_config.dart
@@ -147,52 +147,15 @@ class _MfmEmojiConfigLifecycle {
 class MfmEmojiConfig {
   const MfmEmojiConfig._();
 
-  /// シンプルなセットアップ（最も一般的な使用ケース）
+  /// 永続化ストレージ込みのEmojiResolverとMfmRenderConfigを構築
   ///
-  /// [client]を利用して永続化ストレージ込みのEmojiResolverとMfmRenderConfigを構築
-  /// [serverUrl]はサーバーごとに永続ストアを分離するために使用する。
-  /// [client]の所有権は呼び出し元にあり、返されたハンドルの破棄対象には含まれない。
-  /// [emojiSize]は表示上の高さ、[emojiMaxWidth]は任意の最大幅として扱われる。
-  /// [emojiRefreshListenable]が通知すると絵文字メタデータを再解決する。
-  /// [emojiStoreFactory]を指定すると、Isarを開かずに任意のストアを利用できる。
-  static Future<MfmEmojiConfigHandle> quickSetup({
-    required MisskeyClient client,
-    required String serverUrl,
-    String? storagePath,
-    double emojiSize = 24.0,
-    double? emojiMaxWidth,
-    Listenable? emojiRefreshListenable,
-    Widget Function(BuildContext context, String name)? fallbackBuilder,
-    SyncErrorCallback? onSyncError,
-    bool autoSync = true,
-    MfmEmojiStoreFactory? emojiStoreFactory,
-  }) {
-    final uri = _normalizeServerUrl(serverUrl);
-    return createDefault(
-      client: client,
-      serverUrl: uri,
-      storagePath: storagePath,
-      emojiSize: emojiSize,
-      emojiMaxWidth: emojiMaxWidth,
-      emojiRefreshListenable: emojiRefreshListenable,
-      fallbackBuilder: fallbackBuilder,
-      onSyncError: onSyncError,
-      autoSync: autoSync,
-      emojiStoreFactory: emojiStoreFactory,
-    );
-  }
-
-  /// カスタマイズ可能なセットアップ
-  ///
-  /// より詳細な制御が必要な場合に使用
-  /// [serverUrl]はサーバーごとに永続ストアを分離するために使用する。
+  /// 接続先は[client]から導出され、サーバーごとに永続ストアが分離される。
   /// [client]の所有権は呼び出し元にあり、返されたハンドルの破棄対象には含まれない。
   /// [emojiSize]は表示上の高さ、[emojiMaxWidth]は任意の最大幅として扱われる。
   /// [emojiRefreshListenable]が通知すると絵文字メタデータを再解決する。
   /// [emojiStoreFactory]を指定すると、Isarを開かずに任意のストアを利用できる。
   static Future<MfmEmojiConfigHandle> createDefault({
     required MisskeyClient client,
-    required Uri serverUrl,
     String? storagePath,
     double emojiSize = 24.0,
     double? emojiMaxWidth,
@@ -209,7 +172,7 @@ class MfmEmojiConfig {
     await Directory(directory).create(recursive: true);
 
     final store = await (emojiStoreFactory ?? _createDefaultStore)(
-      serverUrl: serverUrl,
+      serverUrl: client.baseUrl,
       directory: directory,
     );
 
@@ -312,13 +275,5 @@ class MfmEmojiConfig {
       directory: directory,
     );
     return IsarEmojiStore(isar, ownsIsar: true);
-  }
-
-  static Uri _normalizeServerUrl(String serverUrl) {
-    final parsed = Uri.parse(serverUrl);
-    if (parsed.hasScheme) {
-      return parsed;
-    }
-    return Uri.parse('https://$serverUrl');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,15 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_highlight: ^0.7.0
-  misskey_api_core: ^1.0.0
-  misskey_emoji: ^1.0.0
+  misskey_client: ^1.0.0-beta.5
+  misskey_emoji: ^2.0.0-beta.1
   misskey_mfm_parser: ^2.0.0
   path_provider: ^2.1.5
   timeago: ^3.7.1
+
+dependency_overrides:
+  misskey_emoji:
+    path: ../misskey_emoji
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,15 +12,12 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_highlight: ^0.7.0
-  misskey_client: ^1.0.0-beta.5
+  misskey_client: ^1.0.0-beta.6
   misskey_emoji: ^2.0.0-beta.1
   misskey_mfm_parser: ^2.0.0
   path_provider: ^2.1.5
   timeago: ^3.7.1
 
-dependency_overrides:
-  misskey_emoji:
-    path: ../misskey_emoji
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/test/unit/emoji_config_test.dart
+++ b/test/unit/emoji_config_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_client/misskey_client.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
 
 void main() {
@@ -45,6 +46,7 @@ void main() {
     });
 
     final config = await MfmEmojiConfig.quickSetup(
+      client: _createClient(),
       serverUrl: 'example.com',
       storagePath: dir.path,
       autoSync: false,
@@ -76,6 +78,7 @@ void main() {
     });
 
     final config = await MfmEmojiConfig.createDefault(
+      client: _createClient(),
       serverUrl: Uri.parse('https://example.com'),
       storagePath: dir.path,
       autoSync: false,
@@ -106,6 +109,7 @@ void main() {
     });
 
     final config = await MfmEmojiConfig.createDefault(
+      client: _createClient(),
       serverUrl: Uri.parse('https://example.com'),
       storagePath: dir.path,
       autoSync: false,
@@ -122,6 +126,10 @@ void main() {
     expect(store.disposeCalls, 1);
   });
 }
+
+MisskeyClient _createClient() => MisskeyClient(
+  config: MisskeyClientConfig(baseUrl: Uri.parse('https://example.com')),
+);
 
 class _FakeEmojiStore implements EmojiStore {
   int disposeCalls = 0;

--- a/test/unit/emoji_config_test.dart
+++ b/test/unit/emoji_config_test.dart
@@ -36,7 +36,7 @@ void main() {
     expect(custom.refreshListenable, same(refreshNotifier));
   });
 
-  test('quickSetup returns config with emojiBuilder', () async {
+  test('createDefault derives the store scope from client.baseUrl', () async {
     final dir = await Directory.systemTemp.createTemp('mfm_emoji_quick');
     final store = _FakeEmojiStore();
     Uri? factoryServerUrl;
@@ -45,9 +45,8 @@ void main() {
       await dir.delete(recursive: true);
     });
 
-    final config = await MfmEmojiConfig.quickSetup(
+    final config = await MfmEmojiConfig.createDefault(
       client: _createClient(),
-      serverUrl: 'example.com',
       storagePath: dir.path,
       autoSync: false,
       emojiStoreFactory: ({required Uri serverUrl, required String directory}) {
@@ -79,7 +78,6 @@ void main() {
 
     final config = await MfmEmojiConfig.createDefault(
       client: _createClient(),
-      serverUrl: Uri.parse('https://example.com'),
       storagePath: dir.path,
       autoSync: false,
       emojiStoreFactory:
@@ -110,7 +108,6 @@ void main() {
 
     final config = await MfmEmojiConfig.createDefault(
       client: _createClient(),
-      serverUrl: Uri.parse('https://example.com'),
       storagePath: dir.path,
       autoSync: false,
       emojiStoreFactory:


### PR DESCRIPTION
## 概要

`misskey_api_core` の廃止に追随し、絵文字設定ヘルパーを `misskey_client` と `misskey_emoji` 2.0 の `EmojiSource` API へ移行する。

Refs #25 / 親issue: [LibraryLibrarian/misskey_client#31](https://github.com/LibraryLibrarian/misskey_client/issues/31)

MFM のパース・レンダリングという本パッケージの中核は影響を受けない。変更対象は `lib/src/helpers/emoji_config.dart` の依存差し替えのみ。

## 変更内容

- `MisskeyEmojiApi` → `MisskeyClientEmojiSource` に置き換え
- `PersistentEmojiCatalog` の `api` + `meta` → `source` コンストラクタへ追随
- `MisskeyClient` を必須化し、**内部での HTTP クライアント生成を廃止**
- `misskey_api_core` を削除し `misskey_client` を直接依存に追加
- `example/` を新しいシグネチャに追随
- README（英日両セクション）・CHANGELOG を更新

## 破壊的変更

`MfmEmojiConfig.quickSetup` / `createDefault` に `MisskeyClient` が必須引数として追加される。

```dart
// Before
MfmEmojiConfig.quickSetup(serverUrl: 'https://misskey.io');

// After
final client = MisskeyClient(
  config: MisskeyClientConfig(baseUrl: Uri.parse('https://misskey.io')),
);
MfmEmojiConfig.quickSetup(client: client, serverUrl: 'https://misskey.io');
```

### 設計判断

**`serverUrl` のみを受け取る従来の API は残さない。** 従来は絵文字取得のためだけに独立した HTTP クライアントを内部生成しており、アプリが保持するタイムアウト・User-Agent・リトライ回数・認証設定を再利用できなかった。`misskey_emoji` 2.0.0 に依存する時点でメジャー相当の更新になるため、API を1本化した。

**所有権**: 渡された `MisskeyClient` の所有権はアプリ側にある。`MfmEmojiConfigHandle.dispose()` は従来どおりカタログとストアを破棄するが、`MisskeyClient` は破棄しない。

## `serverUrl` を併存させている理由

`client` と `serverUrl` の両方を受け取る形になっており冗長に見えるが、これは **`MisskeyClient` が `baseUrl` を公開していない**ためである。

`MisskeyClient` はコンストラクタで `MisskeyClientConfig` を受け取るが public フィールドとして保持しておらず、`MisskeyClient.http` は `@internal` のため利用できない。`serverUrl` はサーバーごとに永続ストア（Isar DB）を分離する識別子として必要なため、やむを得ず併存させている。

`misskey_client` 側に `baseUrl` のゲッターが追加されれば `serverUrl` は不要になる。別途 issue を起票する。

## 依存関係

```yaml
dependencies:
  misskey_client: ^1.0.0-beta.5
  misskey_emoji: ^2.0.0-beta.1

dependency_overrides:
  misskey_emoji:
    path: ../misskey_emoji
```

**`misskey_emoji 2.0.0-beta.1` は公開待ちである。** `dependency_overrides` は開発中の暫定措置であり、公開後に削除が必要（ルートと `example/` の両方）。**本PRは `misskey_emoji` の公開後にマージすること。**

## 検証

| 項目 | 結果 |
|---|---|
| `flutter analyze`（ルート） | No issues found |
| `flutter analyze`（example） | No issues found |
| `flutter test` | **243件成功** |
| `flutter pub get`（ルート・example 両方） | 成功 |

### 既知の事項

`lib/src/utils/nyaize.dart` に `dart format` 差分があるが、**本PR以前から `develop` に存在するドリフト**であり対象外とした。

## バージョン

破壊的変更のため次期メジャー相当だが、`pubspec.yaml` の version 変更と公開は本PRでは行わない。CHANGELOG の `[Unreleased]` に記載している。