### PR TITLE
0.6.0-beta.1 のバージョン対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0-beta.1] - 2026-08-15
+
 ### Changed
 - **Breaking:** `MfmEmojiConfig.createDefault()` で、呼び出し元が所有する `MisskeyClient` を必須化
   - 絵文字取得専用のHTTPクライアント生成を廃止し、アプリの接続設定・認証情報を再利用

--- a/README.ja.md
+++ b/README.ja.md
@@ -124,7 +124,7 @@ scopeはレイアウトヒントのキャッシュだけを制御し、resolver�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.5.0
+  misskey_mfm_renderer: ^0.6.0-beta.1
   misskey_client: ^1.0.0-beta.5
 ```
 
@@ -227,7 +227,7 @@ import対象パッケージを直接依存に置きたい場合は追加して�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.5.0
+  misskey_mfm_renderer: ^0.6.0-beta.1
   misskey_client: ^1.0.0-beta.5
   misskey_emoji: ^2.0.0-beta.1
   path_provider: ^2.1.5

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.5.0
+  misskey_mfm_renderer: ^0.6.0-beta.1
   misskey_client: ^1.0.0-beta.5
 ```
 
@@ -228,7 +228,7 @@ If your project enforces direct dependencies for imported packages, add:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.5.0
+  misskey_mfm_renderer: ^0.6.0-beta.1
   misskey_client: ^1.0.0-beta.5
   misskey_emoji: ^2.0.0-beta.1
   path_provider: ^2.1.5

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0-beta.1"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: misskey_mfm_renderer
 description: Flutter widget renderer for Misskey MFM (Misskey Flavored Markdown)
-version: 0.5.0
+version: 0.6.0-beta.1
 repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
 
 environment:


### PR DESCRIPTION
## 概要

`0.6.0-beta.1` のリリース準備。バージョン参照を一括更新する。

`dart run tool/bump_version.dart 0.6.0-beta.1` による自動更新のみで、実装の変更は含まない。

Refs #25

## 0.6.0 系列で初のプレリリース

`0.5.0` からの破壊的変更を含む。

- `misskey_api_core` から `misskey_client` への移行、`misskey_emoji` 2.0 の `EmojiSource` API への追随（#26）
- `MfmEmojiConfig.createDefault()` で `MisskeyClient` を必須化（#26）
- `serverUrl` 引数の廃止。`MisskeyClient.baseUrl` から導出する（#26）
- `MfmEmojiConfig.quickSetup()` の削除（#26）
- README の言語別分割、リリース作業の自動化（#27）

### なぜ安定版ではなくプレリリースなのか

本パッケージは `misskey_client 1.0.0-beta.6` と `misskey_emoji 2.0.0-beta.1` という**プレリリース2つに依存**している。この状態で安定版を公開しようとすると `dart pub publish --dry-run` が以下の警告で exit 65 になる。

```
* Packages dependent on a pre-release of another package should themselves be
  published as a pre-release version.
```

`0.6.0` 安定版に進めるのは、上流2つが安定版になってから。

```
misskey_client 1.0.0  →  misskey_emoji 2.0.0  →  misskey_mfm_renderer 0.6.0
```

## 更新ファイル

- `pubspec.yaml` — version
- `CHANGELOG.md` — `[0.6.0-beta.1] - 2026-08-15` の見出しを追加
- `README.md` / `README.ja.md` — インストール例のバージョン（**各2箇所ずつ、計4箇所**）

## 検証

| 項目 | 結果 |
|---|---|
| `dart run tool/verify_release.dart 0.6.0-beta.1` | consistent |
| `dart format --set-exit-if-changed` | 50ファイル、差分なし |
| `flutter analyze --fatal-infos` | No issues found |
| `flutter test` | **252件成功** |
| `dart pub publish --dry-run` | **Package has 0 warnings / exit 0** |

### CI が緑に戻る

これまで `Validate package` が exit 65 で失敗していたが、本PRで解消する。プレリリース依存に関する警告2件が、自身をプレリリースにすることで消えている。

## 移植したリリースツールの初実行

#27 で移植したツールを、はじめて実際のリリースで使用した。

**複数参照対応が正しく機能することを確認できた。** 本リポジトリの README は英日それぞれに `misskey_mfm_renderer: ^x.y.z` が2箇所ずつあり（通常のインストール例と「import対象パッケージを直接依存に置きたい場合」の例）、移植元のツールでは「1ファイルにつき参照はちょうど1つ」という前提で必ず失敗する構成だった。

改修後のツールで4箇所すべてが更新され、旧バージョンの残存が無いことを確認している。
