### PR TITLE
fix: blurのhover解除と300ms遷移を本家に合わせる

### DIFF
--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -1074,7 +1074,11 @@ class _MfmBlurWidget extends StatefulWidget {
 }
 
 class _MfmBlurWidgetState extends State<_MfmBlurWidget> {
+  static const _blurSigma = 6.0;
+  static const _transitionDuration = Duration(milliseconds: 300);
+
   var _isBlurred = true;
+  var _isHovered = false;
 
   void _toggleBlur() {
     setState(() {
@@ -1082,17 +1086,35 @@ class _MfmBlurWidgetState extends State<_MfmBlurWidget> {
     });
   }
 
+  void _setHovered({required bool isHovered}) {
+    setState(() {
+      _isHovered = isHovered;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: _toggleBlur,
-      child: ImageFiltered(
-        enabled: _isBlurred,
-        imageFilter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
-        child: RichText(
-          text: TextSpan(
-            style: widget.baseTextStyle,
-            children: widget.children,
+    final targetSigma = _isBlurred && !_isHovered ? _blurSigma : 0.0;
+
+    return MouseRegion(
+      onEnter: (_) => _setHovered(isHovered: true),
+      onExit: (_) => _setHovered(isHovered: false),
+      child: GestureDetector(
+        onTap: _toggleBlur,
+        child: TweenAnimationBuilder<double>(
+          tween: Tween(end: targetSigma),
+          duration: _transitionDuration,
+          curve: Curves.ease,
+          builder: (context, sigma, child) => ImageFiltered(
+            enabled: sigma > 0,
+            imageFilter: ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
+            child: child,
+          ),
+          child: RichText(
+            text: TextSpan(
+              style: widget.baseTextStyle,
+              children: widget.children,
+            ),
           ),
         ),
       ),

--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -1079,11 +1079,25 @@ class _MfmBlurWidgetState extends State<_MfmBlurWidget> {
 
   var _isBlurred = true;
   var _isHovered = false;
+  PointerDeviceKind? _tapDeviceKind;
 
   void _toggleBlur() {
     setState(() {
       _isBlurred = !_isBlurred;
     });
+  }
+
+  void _handleTapDown(TapDownDetails details) {
+    _tapDeviceKind = details.kind;
+  }
+
+  void _handleTap() {
+    final deviceKind = _tapDeviceKind;
+    _tapDeviceKind = null;
+    if (deviceKind == PointerDeviceKind.mouse) {
+      return;
+    }
+    _toggleBlur();
   }
 
   void _setHovered({required bool isHovered}) {
@@ -1100,7 +1114,9 @@ class _MfmBlurWidgetState extends State<_MfmBlurWidget> {
       onEnter: (_) => _setHovered(isHovered: true),
       onExit: (_) => _setHovered(isHovered: false),
       child: GestureDetector(
-        onTap: _toggleBlur,
+        onTapDown: _handleTapDown,
+        onTapCancel: () => _tapDeviceKind = null,
+        onTap: _handleTap,
         child: TweenAnimationBuilder<double>(
           tween: Tween(end: targetSigma),
           duration: _transitionDuration,

--- a/test/widget/mfm_fn_test.dart
+++ b/test/widget/mfm_fn_test.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -494,6 +495,75 @@ void main() {
       expect(find.byType(ImageFiltered), findsOneWidget);
     });
 
+    testWidgets('hover中はブラーを解除し、exit後に再適用する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: r'$[blur blurred]'),
+          ),
+        ),
+      );
+
+      final imageFilteredFinder = find.byType(ImageFiltered);
+      final mouseRegionFinder = find.ancestor(
+        of: imageFilteredFinder,
+        matching: find.byType(MouseRegion),
+      );
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(mouse.removePointer);
+
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(tester.getCenter(mouseRegionFinder.first));
+      await tester.pumpAndSettle();
+
+      var imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(imageFiltered.enabled, isFalse);
+
+      await mouse.moveTo(const Offset(799, 599));
+      await tester.pumpAndSettle();
+
+      imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(imageFiltered.enabled, isTrue);
+    });
+
+    testWidgets('ブラー強度を300msで補間する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: r'$[blur blurred]'),
+          ),
+        ),
+      );
+
+      final animationFinder = find.byType(TweenAnimationBuilder<double>);
+      final imageFilteredFinder = find.byType(ImageFiltered);
+      final gestureDetectorFinder = find.ancestor(
+        of: imageFilteredFinder,
+        matching: find.byType(GestureDetector),
+      );
+      final animation = tester.widget<TweenAnimationBuilder<double>>(
+        animationFinder,
+      );
+      expect(animation.duration, const Duration(milliseconds: 300));
+
+      await tester.tap(gestureDetectorFinder.first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
+
+      var imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(
+        imageFiltered.imageFilter,
+        isNot(ImageFilter.blur(sigmaX: 6, sigmaY: 6)),
+      );
+      expect(imageFiltered.imageFilter, isNot(ImageFilter.blur()));
+
+      await tester.pump(const Duration(milliseconds: 150));
+
+      imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(imageFiltered.enabled, isFalse);
+      expect(imageFiltered.imageFilter, ImageFilter.blur());
+    });
+
     testWidgets('タップでブラーをトグルできる', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
@@ -503,24 +573,22 @@ void main() {
         ),
       );
 
-      // 初期状態はブラーがかかっている
-      var imageFiltered = tester.widget<ImageFiltered>(
-        find.byType(ImageFiltered),
+      final imageFilteredFinder = find.byType(ImageFiltered);
+      final gestureDetectorFinder = find.ancestor(
+        of: imageFilteredFinder,
+        matching: find.byType(GestureDetector),
       );
-      expect(imageFiltered.enabled, isTrue);
 
-      // タップしてブラーを解除
-      await tester.tap(find.byType(GestureDetector).first);
-      await tester.pump();
+      await tester.tap(gestureDetectorFinder.first);
+      await tester.pumpAndSettle();
 
-      imageFiltered = tester.widget<ImageFiltered>(find.byType(ImageFiltered));
+      var imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
       expect(imageFiltered.enabled, isFalse);
 
-      // 再度タップしてブラーを適用
-      await tester.tap(find.byType(GestureDetector).first);
-      await tester.pump();
+      await tester.tap(gestureDetectorFinder.first);
+      await tester.pumpAndSettle();
 
-      imageFiltered = tester.widget<ImageFiltered>(find.byType(ImageFiltered));
+      imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
       expect(imageFiltered.enabled, isTrue);
     });
   });

--- a/test/widget/mfm_fn_test.dart
+++ b/test/widget/mfm_fn_test.dart
@@ -526,6 +526,41 @@ void main() {
       expect(imageFiltered.enabled, isTrue);
     });
 
+    testWidgets('mouse click後もexitでブラーを再適用する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: r'$[blur blurred]'),
+          ),
+        ),
+      );
+
+      final imageFilteredFinder = find.byType(ImageFiltered);
+      final mouseRegionFinder = find.ancestor(
+        of: imageFilteredFinder,
+        matching: find.byType(MouseRegion),
+      );
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(mouse.removePointer);
+      final center = tester.getCenter(mouseRegionFinder.first);
+
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(center);
+      await tester.pumpAndSettle();
+      await mouse.down(center);
+      await mouse.up();
+      await tester.pumpAndSettle();
+
+      var imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(imageFiltered.enabled, isFalse);
+
+      await mouse.moveTo(const Offset(799, 599));
+      await tester.pumpAndSettle();
+
+      imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(imageFiltered.enabled, isTrue);
+    });
+
     testWidgets('ブラー強度を300msで補間する', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
@@ -562,6 +597,26 @@ void main() {
       imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
       expect(imageFiltered.enabled, isFalse);
       expect(imageFiltered.imageFilter, ImageFilter.blur());
+
+      await tester.tap(gestureDetectorFinder.first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
+
+      imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(imageFiltered.enabled, isTrue);
+      expect(
+        imageFiltered.imageFilter,
+        isNot(ImageFilter.blur(sigmaX: 6, sigmaY: 6)),
+      );
+      expect(imageFiltered.imageFilter, isNot(ImageFilter.blur()));
+
+      await tester.pump(const Duration(milliseconds: 150));
+
+      imageFiltered = tester.widget<ImageFiltered>(imageFilteredFinder);
+      expect(
+        imageFiltered.imageFilter,
+        ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+      );
     });
 
     testWidgets('タップでブラーをトグルできる', (tester) async {


### PR DESCRIPTION
## 概要

`blur` のぼかし解除を本家Misskeyの操作感に合わせます。

## 変更内容

- ぼかし強度を sigma 6 から 0 へ300msで遷移
- デスクトップではhover中のみぼかしを解除し、exit時に再適用
- マウスクリックを永続トグルから除外
- タッチ操作のタップ切り替えを維持
- 解除・再適用の両方向を回帰テストで検証

## 検証

- `flutter test`（255件成功）
- `flutter analyze`（No issues found）
- `git diff --check`

Closes #44
