### PR TITLE
fix: ホスト省略メンションのacctを解決する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -217,6 +217,21 @@ MfmText(
 )
 ```
 
+リモート投稿内のホスト省略メンションを解決するには、投稿者とローカル
+インスタンスのホストを指定します。`onMentionTap`には解決後の完全なacctが
+渡されます。どちらのホストも解決できない場合は、元のacctがそのまま渡されます。
+
+```dart
+MfmText(
+  text: '@alice',
+  config: MfmRenderConfig(
+    author: const MfmAuthorContext(host: 'remote.example'),
+    localHost: 'local.example',
+    onMentionTap: navigateToUser,
+  ),
+)
+```
+
 ### 高度なカスタム絵文字の設定
 
 Misskeyサーバーのカスタム絵文字を表示するには、`misskey_emoji` ライブラリと連携します：

--- a/README.md
+++ b/README.md
@@ -218,6 +218,21 @@ MfmText(
 )
 ```
 
+For hostless mentions in remote posts, provide the author and local instance
+hosts. `onMentionTap` then receives the resolved full acct. When neither host
+can be resolved, the original acct is passed through unchanged.
+
+```dart
+MfmText(
+  text: '@alice',
+  config: MfmRenderConfig(
+    author: const MfmAuthorContext(host: 'remote.example'),
+    localHost: 'local.example',
+    onMentionTap: navigateToUser,
+  ),
+)
+```
+
 ### Advanced Custom Emoji Configuration
 
 To display custom emojis from a Misskey server, integrate the `misskey_emoji` library:

--- a/lib/src/builder/mfm_node_builder.dart
+++ b/lib/src/builder/mfm_node_builder.dart
@@ -290,6 +290,7 @@ class MfmNodeBuilder {
 
   InlineSpan _buildMention(MentionNode node) {
     final onMentionTap = config.onMentionTap;
+    final resolvedAcct = _resolveMentionAcct(node);
     return TextSpan(
       text: node.acct,
       style: const TextStyle(
@@ -297,8 +298,28 @@ class MfmNodeBuilder {
       ),
       recognizer: onMentionTap == null
           ? null
-          : (TapGestureRecognizer()..onTap = () => onMentionTap(node.acct)),
+          : (TapGestureRecognizer()..onTap = () => onMentionTap(resolvedAcct)),
     );
+  }
+
+  String _resolveMentionAcct(MentionNode node) {
+    if (_nonEmptyHost(node.host) != null) {
+      return node.acct;
+    }
+
+    final host =
+        _nonEmptyHost(config.author?.host) ?? _nonEmptyHost(config.localHost);
+    if (host == null) {
+      return node.acct;
+    }
+    return '@${node.username}@$host';
+  }
+
+  String? _nonEmptyHost(String? host) {
+    if (host == null || host.isEmpty) {
+      return null;
+    }
+    return host;
   }
 
   InlineSpan _buildHashtag(HashtagNode node) {

--- a/lib/src/config/mfm_render_config.dart
+++ b/lib/src/config/mfm_render_config.dart
@@ -63,8 +63,11 @@ class MfmRenderConfig {
   /// リンクタップ時のコールバック
   final void Function(String url)? onLinkTap;
 
-  /// メンションタップ時のコールバック
-  /// acctには完全なacct文字列が渡される（例: "@user@example.com"）
+  /// メンションタップ時のコールバック。
+  ///
+  /// [author]または[localHost]からホストを解決できる場合、acctには
+  /// 完全な文字列が渡される（例: "@user@example.com"）。解決情報がなく、
+  /// 元のメンションにもホストがない場合はraw acct（例: "@user"）を渡す。
   final void Function(String acct)? onMentionTap;
 
   /// ハッシュタグタップ時のコールバック

--- a/test/widget/mfm_text_test.dart
+++ b/test/widget/mfm_text_test.dart
@@ -611,6 +611,29 @@ void main() {
       expect(tappedMention, '@alice@local.example');
     });
 
+    testWidgets('投稿者情報がなくてもlocalHostで省略メンションを解決する', (
+      tester,
+    ) async {
+      String? tappedMention;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '@alice',
+              config: MfmRenderConfig(
+                localHost: 'local.example',
+                onMentionTap: (acct) => tappedMention = acct,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      _invokeSpanTap(tester, '@alice');
+      expect(tappedMention, '@alice@local.example');
+    });
+
     testWidgets('明示されたメンションホストを投稿者ホストより優先する', (
       tester,
     ) async {

--- a/test/widget/mfm_text_test.dart
+++ b/test/widget/mfm_text_test.dart
@@ -565,6 +565,126 @@ void main() {
       expect(tappedMention, '@user@example.com');
     });
 
+    testWidgets('リモート投稿者のホストで省略メンションを解決する', (tester) async {
+      String? tappedMention;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '@alice',
+              config: MfmRenderConfig(
+                author: const MfmAuthorContext(host: 'remote.example'),
+                localHost: 'local.example',
+                onMentionTap: (acct) => tappedMention = acct,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      _invokeSpanTap(tester, '@alice');
+      expect(tappedMention, '@alice@remote.example');
+    });
+
+    testWidgets('ローカル投稿者ではlocalHostで省略メンションを解決する', (
+      tester,
+    ) async {
+      String? tappedMention;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '@alice',
+              config: MfmRenderConfig(
+                author: const MfmAuthorContext(),
+                localHost: 'local.example',
+                onMentionTap: (acct) => tappedMention = acct,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      _invokeSpanTap(tester, '@alice');
+      expect(tappedMention, '@alice@local.example');
+    });
+
+    testWidgets('明示されたメンションホストを投稿者ホストより優先する', (
+      tester,
+    ) async {
+      String? tappedMention;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '@alice@explicit.example',
+              config: MfmRenderConfig(
+                author: const MfmAuthorContext(host: 'remote.example'),
+                localHost: 'local.example',
+                onMentionTap: (acct) => tappedMention = acct,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      _invokeSpanTap(tester, '@alice@explicit.example');
+      expect(tappedMention, '@alice@explicit.example');
+    });
+
+    testWidgets('Inherited configの投稿者ホストを明示コールバックと結合する', (
+      tester,
+    ) async {
+      String? tappedMention;
+
+      await tester.pumpWidget(
+        MfmConfig(
+          config: const MfmRenderConfig(
+            author: MfmAuthorContext(host: 'remote.example'),
+            localHost: 'local.example',
+          ),
+          child: MaterialApp(
+            home: Scaffold(
+              body: MfmText(
+                text: '@alice',
+                config: MfmRenderConfig(
+                  onMentionTap: (acct) => tappedMention = acct,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      _invokeSpanTap(tester, '@alice');
+      expect(tappedMention, '@alice@remote.example');
+    });
+
+    testWidgets('解決コンテキストがなければ省略メンションをそのまま渡す', (
+      tester,
+    ) async {
+      String? tappedMention;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '@alice',
+              config: MfmRenderConfig(
+                onMentionTap: (acct) => tappedMention = acct,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      _invokeSpanTap(tester, '@alice');
+      expect(tappedMention, '@alice');
+    });
+
     testWidgets('ハッシュタグタップ時にonHashtagTapが呼ばれる', (tester) async {
       String? tappedTag;
 
@@ -738,4 +858,14 @@ TextSpan? _findSpanWithText(TextSpan parent, String text) {
   }
 
   return null;
+}
+
+void _invokeSpanTap(WidgetTester tester, String text) {
+  final richText = tester.widget<RichText>(find.byType(RichText));
+  final textSpan = richText.text as TextSpan;
+  final targetSpan = _findSpanWithText(textSpan, text);
+  expect(targetSpan, isNotNull);
+  final recognizer = targetSpan?.recognizer;
+  expect(recognizer, isA<TapGestureRecognizer>());
+  (recognizer! as TapGestureRecognizer).onTap?.call();
 }


### PR DESCRIPTION
## 概要

ホストが省略されたメンションについて、解決済みのacctを `onMentionTap` へ渡します。

## 変更内容

- 明示host、投稿者host、ローカルhostの順でメンションhostを解決
- 表示文字列は従来どおり元の `node.acct` を維持
- `onMentionTap` のcallbackだけに解決済みacctを渡す
- コンテキストがない場合は従来のraw acctを維持
- remote author、local fallback、明示host、継承、contextなしをテスト
- callbackの解決規則を英日READMEへ追記

## Stack

- Depends on #60
- Base branch: `feature/issue-49-mention-context`

## 検証

- `flutter test`（260件成功）
- `flutter analyze`（No issues found）
- 親PRとの差分境界と `git diff --check`

Closes #49
