### PR TITLE
fix: 引数なしのflipを水平反転にする

### DIFF
--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -119,11 +119,21 @@ class MfmFnHandler {
 
   static InlineSpan _buildFlip(FnNode node, MfmNodeBuilder builder) {
     final args = node.args;
-    final flipH = args.containsKey('h') || args.containsKey('');
+    final flipH = args.containsKey('h');
     final flipV = args.containsKey('v');
 
-    final scaleX = flipH ? -1.0 : 1.0;
-    final scaleY = flipV ? -1.0 : 1.0;
+    final double scaleX;
+    final double scaleY;
+    if (flipH && flipV) {
+      scaleX = -1.0;
+      scaleY = -1.0;
+    } else if (flipV) {
+      scaleX = 1.0;
+      scaleY = -1.0;
+    } else {
+      scaleX = -1.0;
+      scaleY = 1.0;
+    }
 
     final children = builder.buildNodes(node.children);
 

--- a/test/widget/mfm_fn_test.dart
+++ b/test/widget/mfm_fn_test.dart
@@ -82,18 +82,36 @@ void main() {
   });
 
   group('MfmText fn flip関数', () {
-    testWidgets('引数なしのflipをレンダリングできる', (tester) async {
-      // $[flip text] 引数なしでもレンダリングされるべき
+    testWidgets('引数なしのflipで水平反転する', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: MfmText(text: r'$[flip flipped]'),
+            body: MfmText(text: r'$[flip abc]'),
           ),
         ),
       );
 
-      // Transformウィジェットでレンダリングされる
-      expect(find.byType(Transform), findsWidgets);
+      final transform = tester.widget<Transform>(find.byType(Transform).first);
+      final matrix = transform.transform;
+
+      expect(matrix.entry(0, 0), -1.0);
+      expect(matrix.entry(1, 1), 1.0);
+    });
+
+    testWidgets('未知引数のみのflipで水平反転する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: r'$[flip.unknown abc]'),
+          ),
+        ),
+      );
+
+      final transform = tester.widget<Transform>(find.byType(Transform).first);
+      final matrix = transform.transform;
+
+      expect(matrix.entry(0, 0), -1.0);
+      expect(matrix.entry(1, 1), 1.0);
     });
 
     testWidgets('flip.hで水平反転する', (tester) async {


### PR DESCRIPTION
## 概要

`$[flip text]`（引数なし）が反転しない問題を修正し、本家Misskeyと同じ分岐にします。

## 変更内容

- `h` と `v` の両方がある場合は上下左右反転
- `v` のみの場合は垂直反転
- それ以外（引数なし・`h` のみ・未知引数のみ）は水平反転
- 空文字キーの特別扱いを削除
- 引数なし・未知引数のみで水平反転する回帰テストを追加

## 検証

- `flutter test`（275件成功）
- `flutter analyze --fatal-infos`（No issues found）
- `git diff --check`

Closes #34
