### PR TITLE
fix: ハッシュタグのrecognizerをonHashtagTap未設定時に省略

### DIFF
--- a/lib/src/builder/mfm_node_builder.dart
+++ b/lib/src/builder/mfm_node_builder.dart
@@ -323,15 +323,15 @@ class MfmNodeBuilder {
   }
 
   InlineSpan _buildHashtag(HashtagNode node) {
+    final onHashtagTap = config.onHashtagTap;
     return TextSpan(
       text: '#${node.hashtag}',
       style: const TextStyle(
         color: Color(0xFF0066CC),
       ),
-      recognizer: TapGestureRecognizer()
-        ..onTap = () {
-          config.onHashtagTap?.call(node.hashtag);
-        },
+      recognizer: onHashtagTap == null
+          ? null
+          : (TapGestureRecognizer()..onTap = () => onHashtagTap(node.hashtag)),
     );
   }
 

--- a/test/widget/mfm_text_test.dart
+++ b/test/widget/mfm_text_test.dart
@@ -708,7 +708,23 @@ void main() {
       expect(tappedMention, '@alice');
     });
 
-    testWidgets('ハッシュタグタップ時にonHashtagTapが呼ばれる', (tester) async {
+    testWidgets('onHashtagTap未設定時はハッシュタグのrecognizerがnullになる', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: '#flutter'),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final textSpan = richText.text as TextSpan;
+      final hashtagSpan = _findSpanWithText(textSpan, '#flutter');
+      expect(hashtagSpan, isNotNull);
+      expect(hashtagSpan!.recognizer, isNull);
+    });
+
+    testWidgets('onHashtagTap設定時はrecognizerがありタップで#なしのタグ名を渡す', (tester) async {
       String? tappedTag;
 
       await tester.pumpWidget(
@@ -730,10 +746,10 @@ void main() {
       final hashtagSpan = _findSpanWithText(textSpan, '#flutter');
       expect(hashtagSpan, isNotNull);
 
-      final hashtagRecognizer = hashtagSpan?.recognizer;
-      if (hashtagRecognizer is TapGestureRecognizer) {
-        hashtagRecognizer.onTap?.call();
-      }
+      expect(hashtagSpan!.recognizer, isA<TapGestureRecognizer>());
+      expect(tappedTag, isNull);
+
+      await tester.tap(find.byType(RichText));
 
       expect(tappedTag, 'flutter');
     });


### PR DESCRIPTION
## 概要

`_buildHashtag` が `onHashtagTap` の設定有無にかかわらず `TapGestureRecognizer` を生成していたため、他のタップ可能ノードと同じnullガード方式に揃えます。

## 変更内容

- `onHashtagTap` 未設定時は `recognizer` を `null` にする
- 設定時は `TapGestureRecognizer` を生成し、`#` を除いたタグ名を渡す
- 未設定時に `recognizer` が `null` になるテストを追加
- 設定時のテストを実際のタップ操作で検証する形に強化

## 検証

- `flutter test`（275件成功）
- `flutter analyze --fatal-infos`（No issues found）
- `git diff --check`

Closes #58
