### PR TITLE
fix: speed/delayのパースを本家validTimeに合わせる

### DIFF
--- a/lib/src/fn/animated/mfm_animated_wrapper.dart
+++ b/lib/src/fn/animated/mfm_animated_wrapper.dart
@@ -111,46 +111,23 @@ class MfmAnimatedWrapper extends StatefulWidget {
   final Curve curve;
   final Curve? reverseCurve;
 
-  /// `value` は num（秒）または "1.5s" の形式を受け付ける。
+  /// 本家 Misskey の validTime と同じく、`^-?[0-9.]+s$` に一致する
+  /// 文字列のみを受け付ける。前後の空白は除去しない。
   ///
-  /// 未指定・不正値は null、有限の数値は符号を保った Duration を返す。
-  /// 正の極小値を失わないよう、マイクロ秒単位で変換する。
+  /// 未指定・不正値・数値に変換できない値は null を返す。
+  /// 有限の秒数は符号を保ち、マイクロ秒単位で Duration に変換する。
   static Duration? parseTime(Object? value) {
-    if (value == null) return null;
-    if (value is Duration) return value;
+    if (value is! String) return null;
 
-    double? seconds;
-    if (value is num) {
-      seconds = value.toDouble();
-    } else if (value is String) {
-      final trimmed = value.trim();
-      final match = RegExp(r'^(-?[\d.]+)s$').firstMatch(trimmed);
-      if (match != null) {
-        seconds = double.tryParse(match.group(1)!);
-      } else {
-        seconds = double.tryParse(trimmed);
-      }
-    }
+    final match = RegExp(r'^(-?[0-9.]+)s$').firstMatch(value);
+    if (match == null) return null;
 
-    if (seconds == null || seconds.isNaN || seconds.isInfinite) {
+    final seconds = double.tryParse(match.group(1)!);
+    if (seconds == null || !seconds.isFinite) {
       return null;
     }
 
     return Duration(microseconds: (seconds * 1000000).round());
-  }
-
-  /// `parseTime` の結果が null の場合に `fallback` を返す。
-  static Duration parseTimeOrDefault(Object? value, Duration fallback) {
-    return parseTime(value) ?? fallback;
-  }
-
-  /// Map形式の引数から時間を取り出してパースするヘルパー。
-  static Duration parseTimeFromArgs(
-    Map<String, Object?> args,
-    String key,
-    Duration fallback,
-  ) {
-    return parseTime(args[key]) ?? fallback;
   }
 
   @override
@@ -236,9 +213,7 @@ class _MfmAnimatedWrapperState extends State<MfmAnimatedWrapper>
     if (widget.repeat) {
       // 負の delay は、CSS と同様にその時間だけ進行済みの位相から
       // 始める。位相計算は _MfmRepeatingProgressAnimation が担う。
-      _controller.repeat(
-        reverse: widget.reverse && !widget.delay.isNegative,
-      );
+      _controller.repeat(reverse: widget.reverse && !widget.delay.isNegative);
       return;
     }
 

--- a/test/widget/mfm_animation_time_test.dart
+++ b/test/widget/mfm_animation_time_test.dart
@@ -11,29 +11,115 @@ void main() {
         const Duration(microseconds: 400),
       );
       expect(
-        MfmAnimatedWrapper.parseTime(0.000001),
+        MfmAnimatedWrapper.parseTime('0.000001s'),
         const Duration(microseconds: 1),
       );
     });
 
     test('ゼロと負数の符号をフォールバックと区別できる', () {
       expect(MfmAnimatedWrapper.parseTime('0s'), Duration.zero);
-      expect(
-        MfmAnimatedWrapper.parseTime('-1s'),
-        const Duration(seconds: -1),
-      );
+      expect(MfmAnimatedWrapper.parseTime('-1s'), const Duration(seconds: -1));
     });
 
     test('Durationで表現できない極小値はゼロになる', () {
       expect(MfmAnimatedWrapper.parseTime('0.0000004s'), Duration.zero);
     });
 
-    test('未指定・不正値・非有限値はnullになる', () {
-      expect(MfmAnimatedWrapper.parseTime(null), isNull);
-      expect(MfmAnimatedWrapper.parseTime('invalid'), isNull);
-      expect(MfmAnimatedWrapper.parseTime(double.nan), isNull);
-      expect(MfmAnimatedWrapper.parseTime(double.infinity), isNull);
-    });
+    for (final entry in const <String, Duration>{
+      '2s': Duration(seconds: 2),
+      '.5s': Duration(milliseconds: 500),
+      '1.s': Duration(seconds: 1),
+    }.entries) {
+      test('${entry.key}は秒数として受理する', () {
+        expect(MfmAnimatedWrapper.parseTime(entry.key), entry.value);
+      });
+    }
+
+    for (final entry in <String, Object?>{
+      '未指定': null,
+      '単位なしの文字列': '2',
+      '整数': 2,
+      '小数': 0.000001,
+      'true': true,
+      'false': false,
+      'Duration': const Duration(seconds: 2),
+      '前後の空白': ' 2s ',
+      '先頭の空白': ' 2s',
+      '末尾の空白': '2s ',
+      '不正な文字列': 'abc',
+      '空文字列': '',
+      '複数の小数点': '1.2.3s',
+      '数字なし': '.s',
+      '正符号': '+2s',
+      '指数表記': '2e1s',
+      'ミリ秒単位': '2ms',
+      '大文字の単位': '2S',
+      'NaN': double.nan,
+      '無限大': double.infinity,
+    }.entries) {
+      test('${entry.key}はnullになる', () {
+        expect(MfmAnimatedWrapper.parseTime(entry.value), isNull);
+      });
+    }
+  });
+
+  group('speedとdelayの書式', () {
+    const defaultDurations = <String, Duration>{
+      'spin': Duration(milliseconds: 1500),
+      'jump': Duration(milliseconds: 750),
+      'bounce': Duration(milliseconds: 750),
+      'rainbow': Duration(seconds: 1),
+      'shake': Duration(milliseconds: 500),
+      'twitch': Duration(milliseconds: 500),
+      'tada': Duration(seconds: 1),
+      'jelly': Duration(seconds: 1),
+    };
+
+    for (final entry in defaultDurations.entries) {
+      for (final args in <String>[
+        'speed=2,delay=2',
+        'speed,delay',
+        'speed=abc,delay=abc',
+        'speed=1.2.3s,delay=1.2.3s',
+      ]) {
+        testWidgets('${entry.key}の$argsは既定値にフォールバックする', (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: MfmText(text: '\$[${entry.key}.$args test]'),
+              ),
+            ),
+          );
+
+          expect(tester.takeException(), isNull);
+          final wrapper = tester.widget<MfmAnimatedWrapper>(
+            find.byType(MfmAnimatedWrapper),
+          );
+          expect(wrapper.duration, entry.value);
+          expect(wrapper.delay, Duration.zero);
+        });
+      }
+
+      testWidgets('${entry.key}のs付きspeedとdelayは指定秒数を使う', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MfmText(text: '\$[${entry.key}.speed=2s,delay=2s test]'),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        final wrapper = tester.widget<MfmAnimatedWrapper>(
+          find.byType(MfmAnimatedWrapper),
+        );
+        expect(wrapper.duration, const Duration(seconds: 2));
+        expect(wrapper.delay, const Duration(seconds: 2));
+
+        await tester.pump(const Duration(seconds: 2));
+        expect(tester.takeException(), isNull);
+      });
+    }
   });
 
   group('ゼロ以下のspeed', () {
@@ -53,9 +139,7 @@ void main() {
         testWidgets('$fn.speed=$speed は例外なく静止表示する', (tester) async {
           await tester.pumpWidget(
             MaterialApp(
-              home: Scaffold(
-                body: MfmText(text: '\$[$fn.speed=$speed test]'),
-              ),
+              home: Scaffold(body: MfmText(text: '\$[$fn.speed=$speed test]')),
             ),
           );
 
@@ -79,9 +163,7 @@ void main() {
       expect(hasOnePointFiveScale, isTrue);
     });
 
-    testWidgets('rainbowはspeed=0sでは静的グラデーションを適用しない', (
-      tester,
-    ) async {
+    testWidgets('rainbowはspeed=0sでは静的グラデーションを適用しない', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(body: MfmText(text: r'$[rainbow.speed=0s test]')),
@@ -118,9 +200,7 @@ void main() {
       testWidgets('$fn.speed=0.0004s は400マイクロ秒で再生する', (tester) async {
         await tester.pumpWidget(
           MaterialApp(
-            home: Scaffold(
-              body: MfmText(text: '\$[$fn.speed=0.0004s test]'),
-            ),
+            home: Scaffold(body: MfmText(text: '\$[$fn.speed=0.0004s test]')),
           ),
         );
 
@@ -141,9 +221,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: MfmText(
-              text: r'$[spin.speed=2s,delay=-0.5s test]',
-            ),
+            body: MfmText(text: r'$[spin.speed=2s,delay=-0.5s test]'),
           ),
         ),
       );
@@ -174,9 +252,7 @@ void main() {
   });
 
   group('MfmAnimatedWrapperの防御', () {
-    testWidgets('Duration.zeroではbuilderとcontrollerを開始しない', (
-      tester,
-    ) async {
+    testWidgets('Duration.zeroではbuilderとcontrollerを開始しない', (tester) async {
       var buildCount = 0;
 
       await tester.pumpWidget(


### PR DESCRIPTION
## 概要

アニメーション fn の `speed` / `delay` のパースを本家Misskeyの `validTime` と同じ判定にします。

## 変更内容

- `^-?[0-9.]+s$` に一致する文字列のみ受理し、末尾の `s` を必須にする
- 単位なし数値（`speed=2`）、`num` 型、`bool` 型、前後に空白のある値は既定値へフォールバック
- 前後の空白除去（`trim()`）を廃止し、本家と同じく不一致扱いにする
- 未使用だった `Duration` 直接受理、`parseTimeOrDefault`、`parseTimeFromArgs` を削除
- 正常・異常ケースの単体テストと、8種のアニメーション fn に対する `speed` / `delay` の既定値フォールバック回帰テストを追加

## 検証

- `flutter test`（336件成功）
- `flutter analyze --fatal-infos`（No issues found）
- `git diff --check`

Closes #45
