### PR TITLE
fix: コードブロックのコピー通知をScaffoldMessenger非依存にする

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -238,6 +238,7 @@ MfmText(
       showCopyConfirmation(code);
     },
     // 任意: ローカライズされたコードコピー文言を上書き
+    // （codeCopyTooltip はコピーボタンのアクセシビリティラベル）
     codeCopyTooltip: 'ソースをコピー',
     codeCopiedMessage: 'ソースをコピーしました',
   ),
@@ -250,8 +251,10 @@ SnackBarを表示し、ない場合は通知せずにコピーを完了します
 `codeCopiedMessage` はこの既定のSnackBarでのみ使用します。文言を上書きしない場合、
 `codeCopyTooltip` / `codeCopiedMessage` は日本語ロケールで「コピー」/
 「コードをコピーしました」、その他・ロケール未設定時は `Copy` /
-`Copied to clipboard` になります。`Overlay` がない場合はツールチップを省略し、
-アクセシビリティ用のラベルは維持します。
+`Copied to clipboard` になります。コピーボタンはMaterialウィジェットを使わずに
+構成しているため `CupertinoApp` / `WidgetsApp` 配下でも動作します。
+ツールチップは表示せず、`codeCopyTooltip` はコピーボタンの
+アクセシビリティ（Semantics）ラベルとして機能します。
 
 コードブロックは `baseTextStyle.fontSize`（ベーススタイル未設定時は周囲の
 `DefaultTextStyle`）を継承し、フォントファミリーは `monospace` を維持します。
@@ -476,7 +479,7 @@ void main() {
 | `onHashtagTap` | `void Function(String)?` | null | ハッシュタグタップコールバック |
 | `onSearchTap` | `void Function(String)?` | null | 検索タップコールバック |
 | `onCodeCopied` | `void Function(String)?` | null | コードコピー完了コールバック。指定時は既定のSnackBarを置換し、未指定時はScaffoldMessengerの祖先がある場合のみ通知 |
-| `codeCopyTooltip` | `String?` | 現在のロケール | コードコピーツールチップの上書き（日本語は`コピー`、その他は`Copy`） |
+| `codeCopyTooltip` | `String?` | 現在のロケール | コードコピーボタンのアクセシビリティラベルの上書き（日本語は`コピー`、その他は`Copy`） |
 | `codeCopiedMessage` | `String?` | 現在のロケール | コピー完了時の既定のSnackBar文言上書き（日本語は`コードをコピーしました`、その他は`Copied to clipboard`） |
 | `author` | `MfmAuthorContext?` | null | ホスト依存の描画に使用する投稿者情報 |
 | `localHost` | `String?` | null | ホスト解決のフォールバックに使用するローカルMisskeyホスト |

--- a/README.ja.md
+++ b/README.ja.md
@@ -233,9 +233,29 @@ MfmText(
     },
     // 任意: ローカライズされた検索ボタンラベルを上書き
     searchButtonLabel: '検索する',
+    // コードブロックのコピー完了時（既定のSnackBarを置き換える）
+    onCodeCopied: (code) {
+      showCopyConfirmation(code);
+    },
+    // 任意: ローカライズされたコードコピー文言を上書き
+    codeCopyTooltip: 'ソースをコピー',
+    codeCopiedMessage: 'ソースをコピーしました',
   ),
 )
 ```
+
+`onCodeCopied` にはクリップボードへの書き込み完了後にコード全文が渡され、
+既定の通知を置き換えます。省略時は `ScaffoldMessenger` の祖先がある場合だけ
+SnackBarを表示し、ない場合は通知せずにコピーを完了します。
+`codeCopiedMessage` はこの既定のSnackBarでのみ使用します。文言を上書きしない場合、
+`codeCopyTooltip` / `codeCopiedMessage` は日本語ロケールで「コピー」/
+「コードをコピーしました」、その他・ロケール未設定時は `Copy` /
+`Copied to clipboard` になります。`Overlay` がない場合はツールチップを省略し、
+アクセシビリティ用のラベルは維持します。
+
+コードブロックは `baseTextStyle.fontSize`（ベーススタイル未設定時は周囲の
+`DefaultTextStyle`）を継承し、フォントファミリーは `monospace` を維持します。
+サイズ未指定時はシンタックスハイライターの既定値を使用します。
 
 リモート投稿内のホスト省略メンションを解決するには、投稿者とローカル
 インスタンスのホストを指定します。`onMentionTap`には解決後の完全なacctが
@@ -455,6 +475,9 @@ void main() {
 | `onMentionTap` | `void Function(String)?` | null | メンションタップコールバック |
 | `onHashtagTap` | `void Function(String)?` | null | ハッシュタグタップコールバック |
 | `onSearchTap` | `void Function(String)?` | null | 検索タップコールバック |
+| `onCodeCopied` | `void Function(String)?` | null | コードコピー完了コールバック。指定時は既定のSnackBarを置換し、未指定時はScaffoldMessengerの祖先がある場合のみ通知 |
+| `codeCopyTooltip` | `String?` | 現在のロケール | コードコピーツールチップの上書き（日本語は`コピー`、その他は`Copy`） |
+| `codeCopiedMessage` | `String?` | 現在のロケール | コピー完了時の既定のSnackBar文言上書き（日本語は`コードをコピーしました`、その他は`Copied to clipboard`） |
 | `author` | `MfmAuthorContext?` | null | ホスト依存の描画に使用する投稿者情報 |
 | `localHost` | `String?` | null | ホスト解決のフォールバックに使用するローカルMisskeyホスト |
 | `searchButtonLabel` | `String?` | 現在のロケール | 検索ボタンのラベル上書き（日本語は`検索`、その他は`Search`） |

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ MfmText(
       showCopyConfirmation(code);
     },
     // Optional: override the localized code copy labels
+    // (codeCopyTooltip is the copy button's accessibility label)
     codeCopyTooltip: 'Copy source',
     codeCopiedMessage: 'Source copied',
   ),
@@ -252,8 +253,10 @@ replaces the built-in notification. If omitted, a SnackBar is shown only when a
 `codeCopiedMessage` is used only by that built-in SnackBar. When no override is
 provided, `codeCopyTooltip` / `codeCopiedMessage` use `コピー` /
 `コードをコピーしました` for Japanese and `Copy` / `Copied to clipboard` for
-other or unavailable locales. Without an `Overlay`, the tooltip is omitted but
-its accessibility label is retained.
+other or unavailable locales. The copy button is built without Material
+widgets so it also works under `CupertinoApp` / `WidgetsApp`; no tooltip is
+shown and `codeCopyTooltip` serves as the button's accessibility (semantics)
+label.
 
 Code blocks inherit `baseTextStyle.fontSize` (or the surrounding
 `DefaultTextStyle` when no base style is configured), retaining the `monospace`
@@ -477,7 +480,7 @@ void main() {
 | `onHashtagTap` | `void Function(String)?` | null | Hashtag tap callback |
 | `onSearchTap` | `void Function(String)?` | null | Search tap callback |
 | `onCodeCopied` | `void Function(String)?` | null | Code copy completion callback; replaces the default SnackBar, which requires a ScaffoldMessenger ancestor |
-| `codeCopyTooltip` | `String?` | current locale | Code copy tooltip override (`コピー` for Japanese, `Copy` otherwise) |
+| `codeCopyTooltip` | `String?` | current locale | Code copy button accessibility label override (`コピー` for Japanese, `Copy` otherwise) |
 | `codeCopiedMessage` | `String?` | current locale | Default copy SnackBar message override (`コードをコピーしました` for Japanese, `Copied to clipboard` otherwise) |
 | `author` | `MfmAuthorContext?` | null | Author context used for host-dependent rendering |
 | `localHost` | `String?` | null | Local Misskey host used as a host-resolution fallback |

--- a/README.md
+++ b/README.md
@@ -235,9 +235,29 @@ MfmText(
     },
     // Optional: override the localized search button label
     searchButtonLabel: 'Find',
+    // After a code block is copied (replaces the default SnackBar)
+    onCodeCopied: (code) {
+      showCopyConfirmation(code);
+    },
+    // Optional: override the localized code copy labels
+    codeCopyTooltip: 'Copy source',
+    codeCopiedMessage: 'Source copied',
   ),
 )
 ```
+
+`onCodeCopied` receives the full code after the clipboard write completes and
+replaces the built-in notification. If omitted, a SnackBar is shown only when a
+`ScaffoldMessenger` ancestor is available; otherwise copying completes silently.
+`codeCopiedMessage` is used only by that built-in SnackBar. When no override is
+provided, `codeCopyTooltip` / `codeCopiedMessage` use `コピー` /
+`コードをコピーしました` for Japanese and `Copy` / `Copied to clipboard` for
+other or unavailable locales. Without an `Overlay`, the tooltip is omitted but
+its accessibility label is retained.
+
+Code blocks inherit `baseTextStyle.fontSize` (or the surrounding
+`DefaultTextStyle` when no base style is configured), retaining the `monospace`
+font family. If the size is unspecified, the highlighter's default is used.
 
 For hostless mentions in remote posts, provide the author and local instance
 hosts. `onMentionTap` then receives the resolved full acct. When neither host
@@ -456,6 +476,9 @@ void main() {
 | `onMentionTap` | `void Function(String)?` | null | Mention tap callback |
 | `onHashtagTap` | `void Function(String)?` | null | Hashtag tap callback |
 | `onSearchTap` | `void Function(String)?` | null | Search tap callback |
+| `onCodeCopied` | `void Function(String)?` | null | Code copy completion callback; replaces the default SnackBar, which requires a ScaffoldMessenger ancestor |
+| `codeCopyTooltip` | `String?` | current locale | Code copy tooltip override (`コピー` for Japanese, `Copy` otherwise) |
+| `codeCopiedMessage` | `String?` | current locale | Default copy SnackBar message override (`コードをコピーしました` for Japanese, `Copied to clipboard` otherwise) |
 | `author` | `MfmAuthorContext?` | null | Author context used for host-dependent rendering |
 | `localHost` | `String?` | null | Local Misskey host used as a host-resolution fallback |
 | `searchButtonLabel` | `String?` | current locale | Search button label override (`検索` for Japanese, `Search` otherwise) |

--- a/lib/src/builder/mfm_node_builder.dart
+++ b/lib/src/builder/mfm_node_builder.dart
@@ -176,6 +176,7 @@ class MfmNodeBuilder {
         onCodeCopied: config.onCodeCopied,
         copyTooltip: config.codeCopyTooltip,
         copiedMessage: config.codeCopiedMessage,
+        fontSize: config.baseTextStyle?.fontSize,
       ),
     );
   }

--- a/lib/src/builder/mfm_node_builder.dart
+++ b/lib/src/builder/mfm_node_builder.dart
@@ -173,6 +173,9 @@ class MfmNodeBuilder {
         language: node.language,
         theme: _getCodeTheme(),
         showCopyButton: config.showCodeBlockCopyButton ?? true,
+        onCodeCopied: config.onCodeCopied,
+        copyTooltip: config.codeCopyTooltip,
+        copiedMessage: config.codeCopiedMessage,
       ),
     );
   }

--- a/lib/src/config/mfm_render_config.dart
+++ b/lib/src/config/mfm_render_config.dart
@@ -38,6 +38,9 @@ class MfmRenderConfig {
     this.codeDarkTheme,
     this.brightness,
     this.showCodeBlockCopyButton,
+    this.onCodeCopied,
+    this.codeCopyTooltip,
+    this.codeCopiedMessage,
     this.inlineCodeBgColorLight,
     this.inlineCodeBgColorDark,
   }) : searchButtonLabel = useLocaleSearchButtonLabel
@@ -141,6 +144,23 @@ class MfmRenderConfig {
   /// デフォルトはtrue
   final bool? showCodeBlockCopyButton;
 
+  /// コードをクリップボードへコピーした後のコールバック。
+  ///
+  /// codeにはコピーしたコード全文が渡される。指定時は既定のSnackBarを表示しない。
+  /// nullの場合はScaffoldMessengerが存在するときだけSnackBarを表示する。
+  final void Function(String code)? onCodeCopied;
+
+  /// コードブロックのコピーボタンのツールチップ。
+  ///
+  /// nullの場合は現在のロケールが日本語なら「コピー」、それ以外は"Copy"を使用。
+  final String? codeCopyTooltip;
+
+  /// コードコピー完了時の既定のSnackBarメッセージ。
+  ///
+  /// nullの場合は現在のロケールが日本語なら「コードをコピーしました」、
+  /// それ以外は"Copied to clipboard"を使用。[onCodeCopied]指定時は使用しない。
+  final String? codeCopiedMessage;
+
   /// インラインコード・数式の背景色（ライトモード）
   /// nullの場合は #F5F5F5 を使用（Misskey本家に準拠）
   final Color? inlineCodeBgColorLight;
@@ -179,6 +199,9 @@ class MfmRenderConfig {
     Map<String, TextStyle>? codeDarkTheme,
     Brightness? brightness,
     bool? showCodeBlockCopyButton,
+    void Function(String code)? onCodeCopied,
+    String? codeCopyTooltip,
+    String? codeCopiedMessage,
     Color? inlineCodeBgColorLight,
     Color? inlineCodeBgColorDark,
   }) {
@@ -224,6 +247,9 @@ class MfmRenderConfig {
       brightness: brightness ?? this.brightness,
       showCodeBlockCopyButton:
           showCodeBlockCopyButton ?? this.showCodeBlockCopyButton,
+      onCodeCopied: onCodeCopied ?? this.onCodeCopied,
+      codeCopyTooltip: codeCopyTooltip ?? this.codeCopyTooltip,
+      codeCopiedMessage: codeCopiedMessage ?? this.codeCopiedMessage,
       inlineCodeBgColorLight:
           inlineCodeBgColorLight ?? this.inlineCodeBgColorLight,
       inlineCodeBgColorDark:

--- a/lib/src/config/mfm_render_config.dart
+++ b/lib/src/config/mfm_render_config.dart
@@ -150,8 +150,10 @@ class MfmRenderConfig {
   /// nullの場合はScaffoldMessengerが存在するときだけSnackBarを表示する。
   final void Function(String code)? onCodeCopied;
 
-  /// コードブロックのコピーボタンのツールチップ。
+  /// コードブロックのコピーボタンのアクセシビリティラベル。
   ///
+  /// コピーボタンはMaterial依存を避けるためツールチップを表示せず、
+  /// この文言はSemanticsのラベルとして機能する。
   /// nullの場合は現在のロケールが日本語なら「コピー」、それ以外は"Copy"を使用。
   final String? codeCopyTooltip;
 

--- a/lib/src/helpers/emoji_config.dart
+++ b/lib/src/helpers/emoji_config.dart
@@ -49,6 +49,9 @@ class MfmEmojiConfigHandle extends MfmRenderConfig {
          codeDarkTheme: config.codeDarkTheme,
          brightness: config.brightness,
          showCodeBlockCopyButton: config.showCodeBlockCopyButton,
+         onCodeCopied: config.onCodeCopied,
+         codeCopyTooltip: config.codeCopyTooltip,
+         codeCopiedMessage: config.codeCopiedMessage,
          inlineCodeBgColorLight: config.inlineCodeBgColorLight,
          inlineCodeBgColorDark: config.inlineCodeBgColorDark,
        );
@@ -93,6 +96,9 @@ class MfmEmojiConfigHandle extends MfmRenderConfig {
     Map<String, TextStyle>? codeDarkTheme,
     Brightness? brightness,
     bool? showCodeBlockCopyButton,
+    void Function(String code)? onCodeCopied,
+    String? codeCopyTooltip,
+    String? codeCopiedMessage,
     Color? inlineCodeBgColorLight,
     Color? inlineCodeBgColorDark,
   }) {
@@ -119,6 +125,9 @@ class MfmEmojiConfigHandle extends MfmRenderConfig {
       codeDarkTheme: codeDarkTheme,
       brightness: brightness,
       showCodeBlockCopyButton: showCodeBlockCopyButton,
+      onCodeCopied: onCodeCopied,
+      codeCopyTooltip: codeCopyTooltip,
+      codeCopiedMessage: codeCopiedMessage,
       inlineCodeBgColorLight: inlineCodeBgColorLight,
       inlineCodeBgColorDark: inlineCodeBgColorDark,
     );

--- a/lib/src/mfm_text.dart
+++ b/lib/src/mfm_text.dart
@@ -141,6 +141,10 @@ MfmRenderConfig _mergeConfigs(
     brightness: explicit.brightness ?? inherited.brightness,
     showCodeBlockCopyButton:
         explicit.showCodeBlockCopyButton ?? inherited.showCodeBlockCopyButton,
+    onCodeCopied: explicit.onCodeCopied ?? inherited.onCodeCopied,
+    codeCopyTooltip: explicit.codeCopyTooltip ?? inherited.codeCopyTooltip,
+    codeCopiedMessage:
+        explicit.codeCopiedMessage ?? inherited.codeCopiedMessage,
     inlineCodeBgColorLight:
         explicit.inlineCodeBgColorLight ?? inherited.inlineCodeBgColorLight,
     inlineCodeBgColorDark:
@@ -171,6 +175,9 @@ bool _isDefaultConfig(MfmRenderConfig config) {
       config.codeDarkTheme == defaults.codeDarkTheme &&
       config.brightness == defaults.brightness &&
       config.showCodeBlockCopyButton == defaults.showCodeBlockCopyButton &&
+      config.onCodeCopied == defaults.onCodeCopied &&
+      config.codeCopyTooltip == defaults.codeCopyTooltip &&
+      config.codeCopiedMessage == defaults.codeCopiedMessage &&
       config.inlineCodeBgColorLight == defaults.inlineCodeBgColorLight &&
       config.inlineCodeBgColorDark == defaults.inlineCodeBgColorDark;
 }

--- a/lib/src/widgets/mfm_code_block.dart
+++ b/lib/src/widgets/mfm_code_block.dart
@@ -11,6 +11,9 @@ class MfmCodeBlock extends StatelessWidget {
     this.language,
     required this.theme,
     this.showCopyButton = true,
+    this.onCodeCopied,
+    this.copyTooltip,
+    this.copiedMessage,
     super.key,
   });
 
@@ -26,8 +29,19 @@ class MfmCodeBlock extends StatelessWidget {
   /// コピーボタンを表示するか
   final bool showCopyButton;
 
+  /// コピー完了時のコールバック。指定時は既定のSnackBarを表示しない。
+  final void Function(String code)? onCodeCopied;
+
+  /// コピーボタンのツールチップ。nullの場合は現在のロケールから解決する。
+  final String? copyTooltip;
+
+  /// 既定のSnackBarメッセージ。nullの場合は現在のロケールから解決する。
+  final String? copiedMessage;
+
   @override
   Widget build(BuildContext context) {
+    final isJapanese =
+        Localizations.maybeLocaleOf(context)?.languageCode == 'ja';
     return Container(
       width: double.infinity,
       margin: const EdgeInsets.symmetric(vertical: 8),
@@ -57,7 +71,14 @@ class MfmCodeBlock extends StatelessWidget {
             Positioned(
               top: 8,
               right: 8,
-              child: _CopyButton(code: code),
+              child: _CopyButton(
+                code: code,
+                onCodeCopied: onCodeCopied,
+                tooltip: copyTooltip ?? (isJapanese ? 'コピー' : 'Copy'),
+                copiedMessage:
+                    copiedMessage ??
+                    (isJapanese ? 'コードをコピーしました' : 'Copied to clipboard'),
+              ),
             ),
         ],
       ),
@@ -78,9 +99,17 @@ class MfmCodeBlock extends StatelessWidget {
 
 /// コピーボタンウィジェット
 class _CopyButton extends StatefulWidget {
-  const _CopyButton({required this.code});
+  const _CopyButton({
+    required this.code,
+    required this.onCodeCopied,
+    required this.tooltip,
+    required this.copiedMessage,
+  });
 
   final String code;
+  final void Function(String code)? onCodeCopied;
+  final String tooltip;
+  final String copiedMessage;
 
   @override
   State<_CopyButton> createState() => _CopyButtonState();
@@ -91,33 +120,41 @@ class _CopyButtonState extends State<_CopyButton> {
 
   @override
   Widget build(BuildContext context) {
+    // widgets.dartのみのツリーではTooltipが必要とするOverlayがない場合がある。
+    final canShowTooltip = Overlay.maybeOf(context) != null;
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
       child: Opacity(
         opacity: _isHovered ? 0.8 : 0.5,
-        child: IconButton(
-          icon: const Icon(Icons.content_copy, size: 18),
-          onPressed: _copyToClipboard,
-          tooltip: 'コピー',
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(
-            minWidth: 32,
-            minHeight: 32,
+        child: Semantics(
+          label: canShowTooltip ? null : widget.tooltip,
+          child: IconButton(
+            icon: const Icon(Icons.content_copy, size: 18),
+            onPressed: _copyToClipboard,
+            tooltip: canShowTooltip ? widget.tooltip : null,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(
+              minWidth: 32,
+              minHeight: 32,
+            ),
           ),
         ),
       ),
     );
   }
 
-  void _copyToClipboard() {
-    Clipboard.setData(ClipboardData(text: widget.code));
-    // SnackBarで通知
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('コードをコピーしました'),
-          duration: Duration(seconds: 1),
+  Future<void> _copyToClipboard() async {
+    final code = widget.code;
+    final onCodeCopied = widget.onCodeCopied;
+    await Clipboard.setData(ClipboardData(text: code));
+    if (onCodeCopied != null) {
+      onCodeCopied(code);
+    } else if (mounted) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(
+          content: Text(widget.copiedMessage),
+          duration: const Duration(seconds: 1),
         ),
       );
     }

--- a/lib/src/widgets/mfm_code_block.dart
+++ b/lib/src/widgets/mfm_code_block.dart
@@ -14,6 +14,7 @@ class MfmCodeBlock extends StatelessWidget {
     this.onCodeCopied,
     this.copyTooltip,
     this.copiedMessage,
+    this.fontSize,
     super.key,
   });
 
@@ -38,6 +39,9 @@ class MfmCodeBlock extends StatelessWidget {
   /// 既定のSnackBarメッセージ。nullの場合は現在のロケールから解決する。
   final String? copiedMessage;
 
+  /// コードのフォントサイズ。nullの場合はHighlightViewの既定値を使用する。
+  final double? fontSize;
+
   @override
   Widget build(BuildContext context) {
     final isJapanese =
@@ -60,9 +64,9 @@ class MfmCodeBlock extends StatelessWidget {
               language: language ?? 'plaintext',
               theme: theme,
               padding: EdgeInsets.zero,
-              textStyle: const TextStyle(
+              textStyle: TextStyle(
                 fontFamily: 'monospace',
-                fontSize: 13,
+                fontSize: fontSize,
               ),
             ),
           ),

--- a/lib/src/widgets/mfm_code_block.dart
+++ b/lib/src/widgets/mfm_code_block.dart
@@ -33,7 +33,10 @@ class MfmCodeBlock extends StatelessWidget {
   /// コピー完了時のコールバック。指定時は既定のSnackBarを表示しない。
   final void Function(String code)? onCodeCopied;
 
-  /// コピーボタンのツールチップ。nullの場合は現在のロケールから解決する。
+  /// コピーボタンのアクセシビリティラベル。
+  ///
+  /// Material依存を避けるためツールチップは表示せず、Semanticsのラベルとして扱う。
+  /// nullの場合は現在のロケールから解決する。
   final String? copyTooltip;
 
   /// 既定のSnackBarメッセージ。nullの場合は現在のロケールから解決する。
@@ -112,6 +115,8 @@ class _CopyButton extends StatefulWidget {
 
   final String code;
   final void Function(String code)? onCodeCopied;
+
+  /// アクセシビリティラベルとして使用する文言。
   final String tooltip;
   final String copiedMessage;
 
@@ -124,23 +129,26 @@ class _CopyButtonState extends State<_CopyButton> {
 
   @override
   Widget build(BuildContext context) {
-    // widgets.dartのみのツリーではTooltipが必要とするOverlayがない場合がある。
-    final canShowTooltip = Overlay.maybeOf(context) != null;
+    // IconButtonとTooltipはMaterial（およびOverlay）を必要とするため、
+    // CupertinoApp/WidgetsApp直下でも動作するようにwidgets.dartのみで構成する。
+    // ツールチップの文言はSemanticsのラベルとして提供する。
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
-      child: Opacity(
-        opacity: _isHovered ? 0.8 : 0.5,
-        child: Semantics(
-          label: canShowTooltip ? null : widget.tooltip,
-          child: IconButton(
-            icon: const Icon(Icons.content_copy, size: 18),
-            onPressed: _copyToClipboard,
-            tooltip: canShowTooltip ? widget.tooltip : null,
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(
-              minWidth: 32,
-              minHeight: 32,
+      child: Semantics(
+        button: true,
+        label: widget.tooltip,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _copyToClipboard,
+          child: Opacity(
+            opacity: _isHovered ? 0.8 : 0.5,
+            child: const SizedBox(
+              width: 32,
+              height: 32,
+              child: Center(
+                child: Icon(Icons.content_copy, size: 18),
+              ),
             ),
           ),
         ),

--- a/test/misskey_mfm_renderer_test.dart
+++ b/test/misskey_mfm_renderer_test.dart
@@ -13,6 +13,9 @@ void main() {
       expect(config.localHost, null);
       expect(config.searchButtonLabel, null);
       expect(config.useLocaleSearchButtonLabel, false);
+      expect(config.onCodeCopied, isNull);
+      expect(config.codeCopyTooltip, isNull);
+      expect(config.codeCopiedMessage, isNull);
 
       const localized = MfmRenderConfig(
         searchButtonLabel: 'Ignored',
@@ -50,6 +53,33 @@ void main() {
       );
       expect(overriddenAgain.searchButtonLabel, 'Search again');
       expect(overriddenAgain.useLocaleSearchButtonLabel, isFalse);
+    });
+
+    test('copyWithがコードコピー設定を保持し上書きできる', () {
+      void onCopied(String _) {}
+      void onCopiedOverride(String _) {}
+      final config = MfmRenderConfig(
+        onCodeCopied: onCopied,
+        codeCopyTooltip: 'Copy source',
+        codeCopiedMessage: 'Source copied',
+      );
+
+      final preserved = config.copyWith(enableAnimation: false);
+      expect(preserved.onCodeCopied, same(onCopied));
+      expect(preserved.codeCopyTooltip, 'Copy source');
+      expect(preserved.codeCopiedMessage, 'Source copied');
+
+      final overridden = config.copyWith(
+        onCodeCopied: onCopiedOverride,
+        codeCopyTooltip: '別のツールチップ',
+        codeCopiedMessage: '別のメッセージ',
+      );
+      expect(overridden.onCodeCopied, same(onCopiedOverride));
+      expect(overridden.codeCopyTooltip, '別のツールチップ');
+      expect(overridden.codeCopiedMessage, '別のメッセージ');
+      expect(config.onCodeCopied, same(onCopied));
+      expect(config.codeCopyTooltip, 'Copy source');
+      expect(config.codeCopiedMessage, 'Source copied');
     });
 
     test('copyWith preserves and overrides mention context', () {

--- a/test/unit/emoji_config_test.dart
+++ b/test/unit/emoji_config_test.dart
@@ -69,6 +69,46 @@ void main() {
     expect(store.disposeCalls, 1);
   });
 
+  test('ハンドルのcopyWithがコードコピー設定を保持し上書きできる', () async {
+    final dir = await Directory.systemTemp.createTemp('mfm_emoji_code_copy');
+    addTearDown(() => dir.delete(recursive: true));
+    final store = _FakeEmojiStore();
+    final config = await MfmEmojiConfig.createDefault(
+      client: _createClient(),
+      storagePath: dir.path,
+      autoSync: false,
+      emojiStoreFactory:
+          ({required Uri serverUrl, required String directory}) => store,
+    );
+    addTearDown(config.dispose);
+    void onCopied(String _) {}
+    void onCopiedOverride(String _) {}
+
+    final copied = config.copyWith(
+      onCodeCopied: onCopied,
+      codeCopyTooltip: 'Copy source',
+      codeCopiedMessage: 'Source copied',
+    );
+    final preserved = copied.copyWith(enableAnimation: false);
+    for (final value in [copied, preserved]) {
+      expect(value, isA<MfmEmojiConfigHandle>());
+      expect(value.onCodeCopied, same(onCopied));
+      expect(value.codeCopyTooltip, 'Copy source');
+      expect(value.codeCopiedMessage, 'Source copied');
+    }
+    final overridden = copied.copyWith(
+      onCodeCopied: onCopiedOverride,
+      codeCopyTooltip: '別のツールチップ',
+      codeCopiedMessage: '別のメッセージ',
+    );
+    expect(overridden.onCodeCopied, same(onCopiedOverride));
+    expect(overridden.codeCopyTooltip, '別のツールチップ');
+    expect(overridden.codeCopiedMessage, '別のメッセージ');
+    expect(config.onCodeCopied, isNull);
+    expect(config.codeCopyTooltip, isNull);
+    expect(config.codeCopiedMessage, isNull);
+  });
+
   test('copyWith preserves shared lifecycle ownership', () async {
     final dir = await Directory.systemTemp.createTemp('mfm_emoji_copy');
     final store = _FakeEmojiStore();

--- a/test/widget/mfm_code_block_test.dart
+++ b/test/widget/mfm_code_block_test.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+import 'package:misskey_mfm_renderer/src/widgets/mfm_code_block.dart';
+
+void main() {
+  const code = 'void main() {}';
+  const source = '```dart\n$code\n```';
+  final clipboardCalls = <MethodCall>[];
+  Future<void>? clipboardCompletion;
+
+  setUp(() {
+    clipboardCalls.clear();
+    clipboardCompletion = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardCalls.add(call);
+            await clipboardCompletion;
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  testWidgets('ScaffoldMessengerなしでもコードをコピーできる', (tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: MediaQueryData(),
+          child: MfmText(text: source),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ScaffoldMessenger), findsNothing);
+    expect(find.byType(Scaffold), findsNothing);
+    expect(find.byType(Overlay), findsNothing);
+    expect(find.bySemanticsLabel('Copy'), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pumpAndSettle();
+
+    expect(clipboardCalls.single.arguments, {'text': code});
+    expect(find.byType(SnackBar), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('コピー完了後にコードを通知し既定のSnackBarを表示しない', (tester) async {
+    final completion = Completer<void>();
+    clipboardCompletion = completion.future;
+    final copiedCodes = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MfmText(
+            text: source,
+            config: MfmRenderConfig(onCodeCopied: copiedCodes.add),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pump();
+    expect(clipboardCalls.single.arguments, {'text': code});
+    expect(copiedCodes, isEmpty);
+
+    completion.complete();
+    await tester.pumpAndSettle();
+    expect(copiedCodes, [code]);
+    expect(find.byType(SnackBar), findsNothing);
+  });
+
+  testWidgets('コピー待機中に破棄されてもSnackBarを表示しない', (tester) async {
+    final completion = Completer<void>();
+    clipboardCompletion = completion.future;
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: MfmText(text: source)),
+      ),
+    );
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pumpWidget(const SizedBox.shrink());
+    completion.complete();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
+  for (final locale in ['ja', 'en', 'fr']) {
+    testWidgets('$localeロケールでコピー文言を解決する', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Localizations.override(
+                context: context,
+                locale: Locale(locale),
+                child: const MfmText(text: source),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.widget<IconButton>(find.byType(IconButton)).tooltip,
+        locale == 'ja' ? 'コピー' : 'Copy',
+      );
+      await tester.tap(find.byIcon(Icons.content_copy));
+      await tester.pumpAndSettle();
+      expect(
+        find.text(locale == 'ja' ? 'コードをコピーしました' : 'Copied to clipboard'),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('指定したツールチップとコピー完了メッセージを使用する', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: MfmText(
+            text: source,
+            config: MfmRenderConfig(
+              codeCopyTooltip: 'Copy source',
+              codeCopiedMessage: 'Source copied',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.widget<IconButton>(find.byType(IconButton)).tooltip,
+      'Copy source',
+    );
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pumpAndSettle();
+    expect(find.text('Source copied'), findsOneWidget);
+  });
+
+  testWidgets('同じコードブロックがロケール変更をコピー文言に反映する', (tester) async {
+    final locale = ValueNotifier(const Locale('en'));
+    addTearDown(locale.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ValueListenableBuilder<Locale>(
+            valueListenable: locale,
+            child: const MfmCodeBlock(code: code, theme: {}),
+            builder: (context, currentLocale, child) => Localizations.override(
+              context: context,
+              locale: currentLocale,
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.widget<IconButton>(find.byType(IconButton)).tooltip, 'Copy');
+    locale.value = const Locale('ja');
+    await tester.pumpAndSettle();
+    expect(tester.widget<IconButton>(find.byType(IconButton)).tooltip, 'コピー');
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pumpAndSettle();
+    expect(find.text('コードをコピーしました'), findsOneWidget);
+  });
+}

--- a/test/widget/mfm_code_block_test.dart
+++ b/test/widget/mfm_code_block_test.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_highlight/flutter_highlight.dart';
@@ -53,6 +55,113 @@ void main() {
     expect(clipboardCalls.single.arguments, {'text': code});
     expect(find.byType(SnackBar), findsNothing);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Materialのないツリーでもコピーボタンがタップできる', (tester) async {
+    await tester.pumpWidget(
+      Theme(
+        // Material 2のIconButtonは祖先のMaterialを要求するため、
+        // Material非依存であることを確認する。
+        data: ThemeData(useMaterial3: false),
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: MediaQueryData(),
+            child: MfmText(text: source),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Material), findsNothing);
+    expect(tester.takeException(), isNull);
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pumpAndSettle();
+
+    expect(clipboardCalls.single.arguments, {'text': code});
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('WidgetsApp配下でもコピーボタンがタップできる', (tester) async {
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xFF000000),
+        builder: (context, child) => const MfmText(text: source),
+      ),
+    );
+
+    expect(find.byType(Material), findsNothing);
+    expect(tester.takeException(), isNull);
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pumpAndSettle();
+
+    expect(clipboardCalls.single.arguments, {'text': code});
+    expect(find.byType(SnackBar), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('CupertinoApp配下でもコピーボタンがタップできる', (tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(home: MfmText(text: source)),
+    );
+
+    expect(find.byType(Material), findsNothing);
+    expect(tester.takeException(), isNull);
+    await tester.tap(find.byIcon(Icons.content_copy));
+    await tester.pumpAndSettle();
+
+    expect(clipboardCalls.single.arguments, {'text': code});
+    expect(find.byType(SnackBar), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('コピーボタンはMaterial依存のIconButton/Tooltipを使わない', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: MfmText(text: source)),
+      ),
+    );
+
+    expect(
+      find.descendant(
+        of: find.byType(MfmCodeBlock),
+        matching: find.byType(IconButton),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(MfmCodeBlock),
+        matching: find.byType(Tooltip),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('ホバーでコピーボタンの不透明度が変わる', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: MfmText(text: source)),
+      ),
+    );
+
+    final opacity = find.descendant(
+      of: find.byType(MfmCodeBlock),
+      matching: find.byType(Opacity),
+    );
+    expect(tester.widget<Opacity>(opacity).opacity, 0.5);
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    final center = tester.getCenter(find.byIcon(Icons.content_copy));
+    await tester.sendEventToBinding(pointer.hover(Offset.zero));
+    await tester.pump();
+    await tester.sendEventToBinding(pointer.hover(center));
+    await tester.pump();
+    expect(tester.widget<Opacity>(opacity).opacity, 0.8);
+
+    await tester.sendEventToBinding(pointer.hover(Offset.zero));
+    await tester.pump();
+    expect(tester.widget<Opacity>(opacity).opacity, 0.5);
   });
 
   testWidgets('コピー完了後にコードを通知し既定のSnackBarを表示しない', (tester) async {
@@ -114,8 +223,8 @@ void main() {
       );
 
       expect(
-        tester.widget<IconButton>(find.byType(IconButton)).tooltip,
-        locale == 'ja' ? 'コピー' : 'Copy',
+        find.bySemanticsLabel(locale == 'ja' ? 'コピー' : 'Copy'),
+        findsOneWidget,
       );
       await tester.tap(find.byIcon(Icons.content_copy));
       await tester.pumpAndSettle();
@@ -127,7 +236,7 @@ void main() {
     });
   }
 
-  testWidgets('指定したツールチップとコピー完了メッセージを使用する', (tester) async {
+  testWidgets('指定したアクセシビリティラベルとコピー完了メッセージを使用する', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
@@ -142,10 +251,7 @@ void main() {
       ),
     );
 
-    expect(
-      tester.widget<IconButton>(find.byType(IconButton)).tooltip,
-      'Copy source',
-    );
+    expect(find.bySemanticsLabel('Copy source'), findsOneWidget);
     await tester.tap(find.byIcon(Icons.content_copy));
     await tester.pumpAndSettle();
     expect(find.text('Source copied'), findsOneWidget);
@@ -224,10 +330,10 @@ void main() {
       ),
     );
 
-    expect(tester.widget<IconButton>(find.byType(IconButton)).tooltip, 'Copy');
+    expect(find.bySemanticsLabel('Copy'), findsOneWidget);
     locale.value = const Locale('ja');
     await tester.pumpAndSettle();
-    expect(tester.widget<IconButton>(find.byType(IconButton)).tooltip, 'コピー');
+    expect(find.bySemanticsLabel('コピー'), findsOneWidget);
     await tester.tap(find.byIcon(Icons.content_copy));
     await tester.pumpAndSettle();
     expect(find.text('コードをコピーしました'), findsOneWidget);

--- a/test/widget/mfm_code_block_test.dart
+++ b/test/widget/mfm_code_block_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_highlight/flutter_highlight.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
 import 'package:misskey_mfm_renderer/src/widgets/mfm_code_block.dart';
@@ -148,6 +149,60 @@ void main() {
     await tester.tap(find.byIcon(Icons.content_copy));
     await tester.pumpAndSettle();
     expect(find.text('Source copied'), findsOneWidget);
+  });
+
+  group('コードブロックのフォントサイズ継承', () {
+    final cases = {
+      'baseTextStyle': const MfmText(
+        text: source,
+        config: MfmRenderConfig(baseTextStyle: TextStyle(fontSize: 24)),
+      ),
+      'Inherited config': const MfmConfig(
+        config: MfmRenderConfig(baseTextStyle: TextStyle(fontSize: 24)),
+        child: MfmText(text: source),
+      ),
+      'DefaultTextStyle': const DefaultTextStyle(
+        style: TextStyle(fontSize: 24),
+        child: MfmText(text: source),
+      ),
+    };
+    for (final entry in cases.entries) {
+      testWidgets('${entry.key}のサイズをコード本文に反映する', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(home: Scaffold(body: entry.value)),
+        );
+
+        final highlight = tester.widget<HighlightView>(
+          find.byType(HighlightView),
+        );
+        expect(highlight.textStyle?.fontSize, 24);
+        expect(highlight.textStyle?.fontFamily, 'monospace');
+        final richText = tester.widget<RichText>(
+          find.descendant(
+            of: find.byType(HighlightView),
+            matching: find.byType(RichText),
+          ),
+        );
+        expect(richText.text.style?.fontSize, 24);
+        expect(richText.text.style?.fontFamily, 'monospace');
+      });
+    }
+
+    testWidgets('サイズ未指定ならHighlightViewに固定サイズを渡さない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmCodeBlock(code: code, theme: {}),
+          ),
+        ),
+      );
+
+      final highlight = tester.widget<HighlightView>(
+        find.byType(HighlightView),
+      );
+      expect(highlight.textStyle?.fontSize, isNull);
+      expect(highlight.textStyle?.fontFamily, 'monospace');
+    });
   });
 
   testWidgets('同じコードブロックがロケール変更をコピー文言に反映する', (tester) async {

--- a/test/widget/mfm_inherited_config_test.dart
+++ b/test/widget/mfm_inherited_config_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+import 'package:misskey_mfm_renderer/src/widgets/mfm_code_block.dart';
 
 void main() {
   testWidgets('MfmConfig.of returns inherited config', (tester) async {
@@ -101,6 +102,61 @@ void main() {
     );
 
     expect(find.text('explicit'), findsOneWidget);
+  });
+
+  group('コードコピー設定の継承', () {
+    void inheritedCallback(String _) {}
+    void explicitCallback(String _) {}
+    final inherited = MfmRenderConfig(
+      onCodeCopied: inheritedCallback,
+      codeCopyTooltip: 'Inherited tooltip',
+      codeCopiedMessage: 'Inherited message',
+    );
+
+    final cases = {
+      '既定設定': const MfmRenderConfig(),
+      '既存フィールドのみの明示設定': const MfmRenderConfig(enableAnimation: false),
+      'コールバックのみの明示設定': MfmRenderConfig(onCodeCopied: explicitCallback),
+      'ツールチップのみの明示設定': const MfmRenderConfig(
+        codeCopyTooltip: 'Explicit tooltip',
+      ),
+      '完了メッセージのみの明示設定': const MfmRenderConfig(
+        codeCopiedMessage: 'Explicit message',
+      ),
+    };
+    for (final entry in cases.entries) {
+      testWidgets('${entry.key}と継承したコピー設定を結合する', (tester) async {
+        final explicit = entry.value;
+        await tester.pumpWidget(
+          MfmConfig(
+            config: inherited,
+            child: MaterialApp(
+              home: Scaffold(
+                body: MfmText(text: '```\ncode\n```', config: explicit),
+              ),
+            ),
+          ),
+        );
+
+        final block = tester.widget<MfmCodeBlock>(find.byType(MfmCodeBlock));
+        expect(
+          block.onCodeCopied,
+          same(explicit.onCodeCopied ?? inheritedCallback),
+        );
+        expect(
+          block.copyTooltip,
+          explicit.codeCopyTooltip ?? 'Inherited tooltip',
+        );
+        expect(
+          block.copiedMessage,
+          explicit.codeCopiedMessage ?? 'Inherited message',
+        );
+        expect(
+          tester.widget<IconButton>(find.byType(IconButton)).tooltip,
+          explicit.codeCopyTooltip ?? 'Inherited tooltip',
+        );
+      });
+    }
   });
 
   testWidgets('MfmText inherits searchButtonLabel', (tester) async {

--- a/test/widget/mfm_inherited_config_test.dart
+++ b/test/widget/mfm_inherited_config_test.dart
@@ -152,8 +152,10 @@ void main() {
           explicit.codeCopiedMessage ?? 'Inherited message',
         );
         expect(
-          tester.widget<IconButton>(find.byType(IconButton)).tooltip,
-          explicit.codeCopyTooltip ?? 'Inherited tooltip',
+          find.bySemanticsLabel(
+            explicit.codeCopyTooltip ?? 'Inherited tooltip',
+          ),
+          findsOneWidget,
         );
       });
     }

--- a/test/widget/mfm_text_test.dart
+++ b/test/widget/mfm_text_test.dart
@@ -458,7 +458,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(MfmCodeBlock),
-          matching: find.byType(IconButton),
+          matching: find.byIcon(Icons.content_copy),
         ),
         findsNothing,
       );


### PR DESCRIPTION
## 概要

`MfmCodeBlock` が `ScaffoldMessenger` に依存し、文言が日本語ハードコード、フォントサイズが13px固定だった問題を修正します。枠線・角丸・背景色の見た目差分はテーマ色（#50）と連動するため本PRの範囲外とし、#55 は本PRで実装上の問題のみ解消します。

## 変更内容

- `MfmRenderConfig.onCodeCopied` を追加し、コピー完了通知をアプリ側へ委ねられるようにする
- `onCodeCopied` 未指定時は `ScaffoldMessenger.maybeOf(context)` を使い、祖先がなければ例外を出さずに何もしない
- `codeCopyTooltip`（コピーボタンのアクセシビリティラベル）/ `codeCopiedMessage` を追加し、未指定時はロケールから解決（`ja` は「コピー」「コードをコピーしました」、それ以外は "Copy" / "Copied to clipboard"）
- コピーボタンを `IconButton` / `Tooltip` から `GestureDetector` + `Icon` + `Semantics` に置き換え、Material 非依存にする（`useMaterial3: false` のテーマや `CupertinoApp` / `WidgetsApp` 配下でも動作）。ホバー時のツールチップは表示せず、`codeCopyTooltip` はアクセシビリティラベルとして機能する
- コードブロックの `fontSize: 13` 固定を廃止し、`baseTextStyle.fontSize` を継承
- `copyWith`、Inherited設定のマージ、既定判定、`MfmEmojiConfigHandle` へ新フィールドを伝播
- `Scaffold` なしツリーでのコピー操作、コールバック、文言解決、フォントサイズ継承、設定伝播のテストを追加
- 英日READMEに設定方法を追記

## 検証

- `flutter test`（298件成功）
- `flutter analyze --fatal-infos`（No issues found）
- `git diff --check`

Refs #55

