### PR TITLE
fix: rubyの装飾付きベーステキストとnyaizeに対応

### DIFF
--- a/lib/src/builder/mfm_node_builder.dart
+++ b/lib/src/builder/mfm_node_builder.dart
@@ -43,7 +43,7 @@ class MfmNodeBuilder {
   }
 
   /// 現在の文脈で nyaize 変換を適用すべきか
-  bool get _shouldNyaize => config.enableNyaize && !disableNyaize;
+  bool get shouldNyaize => config.enableNyaize && !disableNyaize;
 
   /// ノードリストをWidgetリストに変換
   List<InlineSpan> buildNodes(List<MfmNode> nodes) {
@@ -79,7 +79,7 @@ class MfmNodeBuilder {
   InlineSpan _buildText(TextNode node) {
     // styleをnullにして親のスタイルを継承
     // ルートのTextSpanでbaseTextStyleが設定されているため、ここで再設定する必要はない
-    final text = _shouldNyaize ? nyaize(node.text) : node.text;
+    final text = shouldNyaize ? nyaize(node.text) : node.text;
     return TextSpan(text: text);
   }
 

--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -7,6 +7,7 @@ import 'package:timeago/timeago.dart' as timeago;
 
 import '../builder/mfm_node_builder.dart';
 import '../utils/color_parser.dart';
+import '../utils/nyaize.dart';
 import 'animated/mfm_animated_wrapper.dart';
 import 'animated/mfm_bounce_widget.dart';
 import 'animated/mfm_jelly_widget.dart';
@@ -739,28 +740,40 @@ class MfmFnHandler {
 
   static InlineSpan _buildRuby(FnNode node, MfmNodeBuilder builder) {
     // ruby構文: $[ruby ベーステキスト ルビテキスト]
-    // 子ノードからテキストを取得、スペースで分割する
-    String? baseText;
-    String? rubyText;
-
-    // 最初のTextNodeからテキストを取得
-    for (final child in node.children) {
-      if (child is TextNode) {
-        final parts = child.text.split(' ');
-        if (parts.length >= 2) {
-          baseText = parts[0];
-          rubyText = parts.sublist(1).join(' ');
-        } else if (parts.length == 1) {
-          baseText = parts[0];
-        }
-        break;
-      }
+    if (node.children.isEmpty) {
+      return TextSpan(children: builder.buildNodes(node.children));
     }
 
-    // ベーステキストまたはルビテキストがない場合は通常のテキストとして表示
-    if (baseText == null || rubyText == null || rubyText.isEmpty) {
-      final children = builder.buildNodes(node.children);
-      return TextSpan(children: children);
+    final InlineSpan baseSpan;
+    final String rubyText;
+    final lastChild = node.children.last;
+    if (node.children.length == 1 && lastChild is TextNode) {
+      // テキストのみの場合、本家と同じく空白分割した2番目だけをルビにする。
+      final parts = lastChild.text.split(' ');
+      if (parts.length < 2 || parts[1].isEmpty) {
+        return TextSpan(children: builder.buildNodes(node.children));
+      }
+      baseSpan = TextSpan(
+        text: builder.shouldNyaize ? nyaize(parts[0]) : parts[0],
+      );
+      rubyText = parts[1];
+    } else {
+      // 最後の子をルビ、それ以外を装飾を保持したベースとして描画する。
+      // TextPainterではルビ側の非テキストノードを描けないため、そのまま表示する。
+      if (lastChild is! TextNode || lastChild.text.trim().isEmpty) {
+        return TextSpan(children: builder.buildNodes(node.children));
+      }
+      baseSpan = TextSpan(
+        children: builder.buildNodes(
+          node.children.sublist(0, node.children.length - 1),
+        ),
+      );
+      rubyText = lastChild.text.trim();
+
+      // TextPainter単体ではWidgetSpanを描けない。ネストしたものも検出する。
+      if (!baseSpan.visitChildren((span) => span is! WidgetSpan)) {
+        return TextSpan(children: builder.buildNodes(node.children));
+      }
     }
 
     final baseStyle = builder.config.baseTextStyle;
@@ -775,8 +788,8 @@ class MfmFnHandler {
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
       child: _RubyTextWidget(
-        baseText: baseText,
-        rubyText: rubyText,
+        baseSpan: baseSpan,
+        rubyText: builder.shouldNyaize ? nyaize(rubyText) : rubyText,
         baseStyle: baseStyle,
         rubyStyle: rubyStyle,
         rubyFontSize: rubyFontSize,
@@ -894,14 +907,14 @@ class MfmFnHandler {
 /// ベーステキストのベースラインを維持しながら、ルビテキストを上に配置
 class _RubyTextWidget extends LeafRenderObjectWidget {
   const _RubyTextWidget({
-    required this.baseText,
+    required this.baseSpan,
     required this.rubyText,
     required this.baseStyle,
     required this.rubyStyle,
     required this.rubyFontSize,
   });
 
-  final String baseText;
+  final InlineSpan baseSpan;
   final String rubyText;
   final TextStyle? baseStyle;
   final TextStyle rubyStyle;
@@ -910,7 +923,7 @@ class _RubyTextWidget extends LeafRenderObjectWidget {
   @override
   RenderObject createRenderObject(BuildContext context) {
     return _RenderRubyText(
-      baseText: baseText,
+      baseSpan: baseSpan,
       rubyText: rubyText,
       baseStyle: baseStyle,
       rubyStyle: rubyStyle,
@@ -924,7 +937,7 @@ class _RubyTextWidget extends LeafRenderObjectWidget {
     _RenderRubyText renderObject,
   ) {
     renderObject
-      ..baseText = baseText
+      ..baseSpan = baseSpan
       ..rubyText = rubyText
       ..baseStyle = baseStyle
       ..rubyStyle = rubyStyle
@@ -934,22 +947,22 @@ class _RubyTextWidget extends LeafRenderObjectWidget {
 
 class _RenderRubyText extends RenderBox {
   _RenderRubyText({
-    required String baseText,
+    required InlineSpan baseSpan,
     required String rubyText,
     required TextStyle? baseStyle,
     required TextStyle rubyStyle,
     required double rubyFontSize,
-  }) : _baseText = baseText,
+  }) : _baseSpan = baseSpan,
        _rubyText = rubyText,
        _baseStyle = baseStyle,
        _rubyStyle = rubyStyle,
        _rubyFontSize = rubyFontSize;
 
-  String _baseText;
-  String get baseText => _baseText;
-  set baseText(String value) {
-    if (_baseText != value) {
-      _baseText = value;
+  InlineSpan _baseSpan;
+  InlineSpan get baseSpan => _baseSpan;
+  set baseSpan(InlineSpan value) {
+    if (_baseSpan != value) {
+      _baseSpan = value;
       _basePainter = null;
       markNeedsLayout();
     }
@@ -999,7 +1012,7 @@ class _RenderRubyText extends RenderBox {
 
   TextPainter _getBasePainter() {
     _basePainter ??= TextPainter(
-      text: TextSpan(text: _baseText, style: _baseStyle),
+      text: TextSpan(style: _baseStyle, children: [_baseSpan]),
       textDirection: TextDirection.ltr,
     );
     return _basePainter!;

--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -748,14 +748,17 @@ class MfmFnHandler {
     final String rubyText;
     final lastChild = node.children.last;
     if (node.children.length == 1 && lastChild is TextNode) {
-      // テキストのみの場合、本家と同じく空白分割した2番目だけをルビにする。
-      final parts = lastChild.text.split(' ');
+      // テキストのみの場合、本家と同じく全文をnyaizeしてから空白分割し、
+      // 2番目だけをルビにする。分割前に変換しないとnyaizeの
+      // 空白依存パターンが分割位置に影響されてしまう。
+      final raw = builder.shouldNyaize
+          ? nyaize(lastChild.text)
+          : lastChild.text;
+      final parts = raw.split(' ');
       if (parts.length < 2 || parts[1].isEmpty) {
         return TextSpan(children: builder.buildNodes(node.children));
       }
-      baseSpan = TextSpan(
-        text: builder.shouldNyaize ? nyaize(parts[0]) : parts[0],
-      );
+      baseSpan = TextSpan(text: parts[0]);
       rubyText = parts[1];
     } else {
       // 最後の子をルビ、それ以外を装飾を保持したベースとして描画する。
@@ -768,7 +771,11 @@ class MfmFnHandler {
           node.children.sublist(0, node.children.length - 1),
         ),
       );
-      rubyText = lastChild.text.trim();
+      // 本家と同じくnyaizeしてからトリムする。
+      // ベース側はbuildNodes経由でnyaizeされる。
+      rubyText =
+          (builder.shouldNyaize ? nyaize(lastChild.text) : lastChild.text)
+              .trim();
 
       // TextPainter単体ではWidgetSpanを描けない。ネストしたものも検出する。
       if (!baseSpan.visitChildren((span) => span is! WidgetSpan)) {
@@ -789,7 +796,7 @@ class MfmFnHandler {
       baseline: TextBaseline.alphabetic,
       child: _RubyTextWidget(
         baseSpan: baseSpan,
-        rubyText: builder.shouldNyaize ? nyaize(rubyText) : rubyText,
+        rubyText: rubyText,
         baseStyle: baseStyle,
         rubyStyle: rubyStyle,
         rubyFontSize: rubyFontSize,

--- a/test/widget/mfm_fn_test.dart
+++ b/test/widget/mfm_fn_test.dart
@@ -734,6 +734,52 @@ void main() {
       expect((renderObject as dynamic).rubyText, 'にゃにか');
     });
 
+    testWidgets('テキストのみのルビは分割前にnyaizeしてベースとルビの両方を変換する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'$[ruby なにか よみな]',
+              config: MfmRenderConfig(enableNyaize: true),
+            ),
+          ),
+        ),
+      );
+
+      expect(rubyFinder, findsOneWidget);
+      final renderObject = tester.renderObject(rubyFinder);
+      final baseSpan = (renderObject as dynamic).baseSpan as InlineSpan;
+      expect(baseSpan.toPlainText(), 'にゃにか');
+      expect((renderObject as dynamic).rubyText, 'よみにゃ');
+    });
+
+    // ko-KRの「다/야」パターンは半角スペースまたは行末が直後にある場合のみ
+    // マッチするため、トリムの前後どちらでnyaizeするかで結果が変わる。
+    // 本家はnyaize後にトリムするので、タブや全角スペースが末尾にある場合は
+    // 変換されない。
+    for (final example in [
+      (name: 'タブ', ruby: '야\t'),
+      (name: '全角スペース', ruby: '야　'),
+      (name: 'タブ・다', ruby: '하다\t'),
+    ]) {
+      testWidgets('装飾付きのルビはトリムの前にnyaizeする：${example.name}', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MfmText(
+                text: '\$[ruby **base** ${example.ruby}]',
+                config: const MfmRenderConfig(enableNyaize: true),
+              ),
+            ),
+          ),
+        );
+
+        expect(rubyFinder, findsOneWidget);
+        final renderObject = tester.renderObject(rubyFinder);
+        expect((renderObject as dynamic).rubyText, example.ruby.trim());
+      });
+    }
+
     for (final example in [
       (name: 'テキストのみ', text: r'$[ruby なにか なにか]'),
       (name: '装飾付き', text: r'$[ruby **なにか** なにか]'),

--- a/test/widget/mfm_fn_test.dart
+++ b/test/widget/mfm_fn_test.dart
@@ -649,6 +649,219 @@ void main() {
   });
 
   group('MfmText fn ruby関数', () {
+    final rubyFinder = find.byWidgetPredicate(
+      (widget) => widget.runtimeType.toString() == '_RubyTextWidget',
+    );
+
+    for (final example in [
+      (text: r'$[ruby 漢字 かんじ]', base: '漢字', ruby: 'かんじ'),
+      (text: r'$[ruby 漢字 かんじ ふりがな]', base: '漢字', ruby: 'かんじ'),
+    ]) {
+      testWidgets('テキストのみのルビは空白分割した2番目を使う：${example.text}', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: MfmText(text: example.text)),
+          ),
+        );
+
+        expect(rubyFinder, findsOneWidget);
+        final renderObject = tester.renderObject(rubyFinder);
+        final baseSpan = (renderObject as dynamic).baseSpan as InlineSpan;
+        expect(baseSpan.toPlainText(), example.base);
+        expect((renderObject as dynamic).rubyText, example.ruby);
+      });
+    }
+
+    testWidgets('装飾付きベースを太字のまま描画し最後の子をルビにする', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: MfmText(text: r'$[ruby **kanji** よみ]')),
+        ),
+      );
+
+      expect(rubyFinder, findsOneWidget);
+      final renderObject = tester.renderObject(rubyFinder);
+      final baseSpan = (renderObject as dynamic).baseSpan as TextSpan;
+      expect(baseSpan.toPlainText(), 'kanji');
+      final boldSpan = _findSpanWithStyle(
+        baseSpan,
+        (style) => style?.fontWeight == FontWeight.bold,
+      );
+      expect(boldSpan?.toPlainText(), 'kanji');
+      expect((renderObject as dynamic).rubyText, 'よみ');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('最後の子以外のベースをすべて保持しルビの前後だけをトリムする', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: r'$[ruby 前**kanji**後 よみ ふりがな ]'),
+          ),
+        ),
+      );
+
+      expect(rubyFinder, findsOneWidget);
+      final renderObject = tester.renderObject(rubyFinder);
+      final baseSpan = (renderObject as dynamic).baseSpan as TextSpan;
+      expect(baseSpan.toPlainText(), '前kanji');
+      expect((renderObject as dynamic).rubyText, '後 よみ ふりがな');
+      expect(
+        _findSpanWithStyle(
+          baseSpan,
+          (style) => style?.fontWeight == FontWeight.bold,
+        )?.toPlainText(),
+        'kanji',
+      );
+    });
+
+    testWidgets('nyaize有効時は漢字のルビを猫語に変換する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'$[ruby 漢字 なにか]',
+              config: MfmRenderConfig(enableNyaize: true),
+            ),
+          ),
+        ),
+      );
+
+      expect(rubyFinder, findsOneWidget);
+      final renderObject = tester.renderObject(rubyFinder);
+      final baseSpan = (renderObject as dynamic).baseSpan as InlineSpan;
+      expect(baseSpan.toPlainText(), '漢字');
+      expect((renderObject as dynamic).rubyText, 'にゃにか');
+    });
+
+    for (final example in [
+      (name: 'テキストのみ', text: r'$[ruby なにか なにか]'),
+      (name: '装飾付き', text: r'$[ruby **なにか** なにか]'),
+    ]) {
+      for (final enabled in [false, true]) {
+        testWidgets('${example.name}のベースとルビがnyaize設定に従う：$enabled', (
+          tester,
+        ) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: MfmText(
+                  text: example.text,
+                  config: MfmRenderConfig(enableNyaize: enabled),
+                ),
+              ),
+            ),
+          );
+
+          expect(rubyFinder, findsOneWidget);
+          final renderObject = tester.renderObject(rubyFinder);
+          final baseSpan = (renderObject as dynamic).baseSpan as InlineSpan;
+          final expected = enabled ? 'にゃにか' : 'なにか';
+          expect(baseSpan.toPlainText(), expected);
+          expect((renderObject as dynamic).rubyText, expected);
+        });
+      }
+
+      testWidgets('引用内では${example.name}のベースとルビをnyaizeしない', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MfmText(
+                text: '> ${example.text}',
+                config: const MfmRenderConfig(enableNyaize: true),
+              ),
+            ),
+          ),
+        );
+
+        expect(rubyFinder, findsOneWidget);
+        final renderObject = tester.renderObject(rubyFinder);
+        final baseSpan = (renderObject as dynamic).baseSpan as InlineSpan;
+        expect(baseSpan.toPlainText(), 'なにか');
+        expect((renderObject as dynamic).rubyText, 'なにか');
+      });
+    }
+
+    for (final text in [
+      r'$[ruby $[spin abc] よみ]',
+      r'$[ruby **$[spin abc]** よみ]',
+    ]) {
+      testWidgets('ベースにWidgetSpanが含まれる場合は子要素をそのまま表示する：$text', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: MfmText(text: text)),
+          ),
+        );
+
+        expect(rubyFinder, findsNothing);
+        final richTexts = tester.widgetList<RichText>(find.byType(RichText));
+        expect(
+          richTexts.any((widget) => widget.text.toPlainText().contains('abc')),
+          isTrue,
+        );
+        expect(
+          richTexts.any((widget) => widget.text.toPlainText().contains(' よみ')),
+          isTrue,
+        );
+        expect(tester.takeException(), isNull);
+      });
+    }
+
+    for (final example in [
+      (text: r'$[ruby 漢字]', expected: '漢字'),
+      (text: r'$[ruby 漢字 ]', expected: '漢字 '),
+      (text: r'$[ruby 漢字 **よみ**]', expected: '漢字 よみ'),
+      (text: r'$[ruby **漢字**]', expected: '漢字'),
+    ]) {
+      testWidgets('ルビがないか最後の子が装飾ノードならそのまま表示する：${example.text}', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: MfmText(text: example.text)),
+          ),
+        );
+
+        expect(rubyFinder, findsNothing);
+        final richTexts = tester.widgetList<RichText>(find.byType(RichText));
+        expect(
+          richTexts.any(
+            (widget) => widget.text.toPlainText() == example.expected,
+          ),
+          isTrue,
+        );
+        expect(tester.takeException(), isNull);
+      });
+    }
+
+    testWidgets('再ビルドでベースのテキストと装飾とルビを更新できる', (tester) async {
+      Future<void> pumpRuby(String text) => tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: MfmText(text: text)),
+        ),
+      );
+
+      await pumpRuby(r'$[ruby 漢字 かんじ]');
+      final originalRenderObject = tester.renderObject(rubyFinder);
+      await pumpRuby(r'$[ruby **kanji** よみ]');
+
+      final renderObject = tester.renderObject(rubyFinder);
+      expect(renderObject, same(originalRenderObject));
+      final baseSpan = (renderObject as dynamic).baseSpan as TextSpan;
+      expect(baseSpan.toPlainText(), 'kanji');
+      expect(
+        _findSpanWithStyle(
+          baseSpan,
+          (style) => style?.fontWeight == FontWeight.bold,
+        )?.toPlainText(),
+        'kanji',
+      );
+      expect((renderObject as dynamic).rubyText, 'よみ');
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('rubyでルビテキストを上に表示できる', (tester) async {
       // 正しいruby構文: $[ruby ベーステキスト ルビテキスト]
       final nodes = [
@@ -667,13 +880,11 @@ void main() {
         ),
       );
 
-      final rubyFinder = find.byWidgetPredicate(
-        (widget) => widget.runtimeType.toString() == '_RubyTextWidget',
-      );
       expect(rubyFinder, findsOneWidget);
 
       final rubyRenderObject = tester.renderObject(rubyFinder);
-      expect((rubyRenderObject as dynamic).baseText, '振り仮名');
+      final baseSpan = (rubyRenderObject as dynamic).baseSpan as InlineSpan;
+      expect(baseSpan.toPlainText(), '振り仮名');
       expect((rubyRenderObject as dynamic).rubyText, 'ふりがな');
     });
   });


### PR DESCRIPTION
## 概要

`$[ruby **漢字** よみ]` のようにベース側へ装飾が入っている場合にベーステキストが消える問題を修正し、ルビにも nyaize を適用します。

## 変更内容

- 本家Misskeyと同じ2分岐にする
  - 子がテキスト1つの場合: 空白分割した1番目をベース、2番目のみをルビにする
  - 子が複数の場合: 最後の子を `trim()` してルビ、残りの子を装飾を保持したベースとして描画
- `_RubyTextWidget` / `_RenderRubyText` のベース側を `String` から `InlineSpan` に変更し、太字などの装飾を `TextPainter` で描画
- ベース側に `WidgetSpan` を含む場合や、ルビ側がテキストでない場合は、例外を出さず子要素の通常表示へフォールバック
- `MfmNodeBuilder` の nyaize 判定を `shouldNyaize` として共有し、本家と同じく全文を nyaize してから空白分割 / trim する順序でルビにも適用（引用内などの抑止文脈では適用しない）
- 装飾付きベース・nyaize・抑止文脈・フォールバック・再ビルドの回帰テストを追加

## 挙動の変更

`$[ruby 漢字 かんじ ふりがな]` のようにテキスト1つで空白が3要素以上ある場合、従来は「かんじ ふりがな」をルビにしていましたが、本家と同じく「かんじ」のみをルビにします。

## 検証

- `flutter test`（296件成功）
- `flutter analyze --fatal-infos`（No issues found）
- `git diff --check`

Closes #35

