### PR TITLE
ci: 未使用のcustom_lintプラグイン設定を削除

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,4 @@
 analyzer:
-  plugins:
-    - custom_lint
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,6 +1,4 @@
 analyzer:
-  plugins:
-    - custom_lint
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"


### PR DESCRIPTION
## 概要

CI の `Flutter stable` ジョブが、最新 Dart の `analysis_options_deprecated_plugins` 警告により `flutter analyze --fatal-infos` で失敗している問題を修正します。

## 変更内容

- `analysis_options.yaml` / `example/analysis_options.yaml` から `analyzer.plugins: [custom_lint]` を削除
- `custom_lint` は本体・example のいずれの `pubspec.yaml` にも依存として存在しておらず、設定だけが残っていたため、削除による解析結果の変化はない

## 検証

- `flutter analyze --fatal-infos`（No issues found）
- `dart format --output=none --set-exit-if-changed .`
- 現在 open している PR（#65〜#71）の `Flutter stable` ジョブがすべて同一の警告で失敗しているため、本PRのマージ後に各ブランチへ `develop` を取り込んで再実行する
