### PR TITLE
fix: WidgetSpan内側のRichTextへ実効スタイルを伝播する

### DIFF
--- a/lib/src/builder/mfm_node_builder.dart
+++ b/lib/src/builder/mfm_node_builder.dart
@@ -13,12 +13,16 @@ import '../widgets/mfm_code_block.dart';
 class MfmNodeBuilder {
   MfmNodeBuilder({
     required this.config,
+    required this.effectiveStyle,
     this.scale = 1.0,
     this.disableNyaize = false,
   });
 
   /// レンダリング設定
   final MfmRenderConfig config;
+
+  /// 祖先ノードの差分スタイルを反映した現在の実効スタイル
+  final TextStyle effectiveStyle;
 
   /// 現在のスケール（ネストしたscale fnで使用）
   final double scale;
@@ -27,19 +31,58 @@ class MfmNodeBuilder {
   /// link / quote / plain など、原文を保ちたいノード配下では true となる
   final bool disableNyaize;
 
-  /// 新しいスケールでビルダーをコピー
-  MfmNodeBuilder withScale(double newScale) {
+  MfmNodeBuilder _copyWith({
+    TextStyle? effectiveStyle,
+    double? scale,
+    bool? disableNyaize,
+  }) {
     return MfmNodeBuilder(
       config: config,
-      scale: newScale,
-      disableNyaize: disableNyaize,
+      effectiveStyle: effectiveStyle ?? this.effectiveStyle,
+      scale: scale ?? this.scale,
+      disableNyaize: disableNyaize ?? this.disableNyaize,
     );
+  }
+
+  /// 新しいスケールでビルダーをコピー
+  MfmNodeBuilder withScale(double newScale) {
+    return _copyWith(scale: newScale);
+  }
+
+  /// 差分スタイル（inherit: true）を実効スタイルに反映したビルダーを返す
+  MfmNodeBuilder withStyle(TextStyle patch) {
+    return _copyWith(effectiveStyle: effectiveStyle.merge(patch));
   }
 
   /// nyaize 変換を抑止したサブツリー用ビルダーを返す
   MfmNodeBuilder _withDisableNyaize() {
     if (disableNyaize) return this;
-    return MfmNodeBuilder(config: config, scale: scale, disableNyaize: true);
+    return _copyWith(disableNyaize: true);
+  }
+
+  /// 差分スタイルをTextSpanに設定し、同じ差分を実効スタイルに反映した
+  /// ビルダーで子ノードを構築する
+  TextSpan buildStyledSpan(
+    TextStyle patch,
+    List<MfmNode> nodes, {
+    GestureRecognizer? recognizer,
+  }) {
+    return TextSpan(
+      style: patch,
+      children: withStyle(patch).buildNodes(nodes),
+      recognizer: recognizer,
+    );
+  }
+
+  /// WidgetSpan内で子ノードを描画するRichTextを、現在の実効スタイルで組む
+  Widget buildInlineRichText(
+    List<InlineSpan> children, {
+    TextAlign textAlign = TextAlign.start,
+  }) {
+    return RichText(
+      textAlign: textAlign,
+      text: TextSpan(style: effectiveStyle, children: children),
+    );
   }
 
   /// 現在の文脈で nyaize 変換を適用すべきか
@@ -84,46 +127,45 @@ class MfmNodeBuilder {
   }
 
   InlineSpan _buildBold(BoldNode node) {
-    final children = buildNodes(node.children);
-    return TextSpan(
-      style: const TextStyle(fontWeight: FontWeight.bold),
-      children: children,
+    return buildStyledSpan(
+      const TextStyle(fontWeight: FontWeight.bold),
+      node.children,
     );
   }
 
   InlineSpan _buildItalic(ItalicNode node) {
-    final children = buildNodes(node.children);
-    return TextSpan(
-      style: const TextStyle(fontStyle: FontStyle.italic),
-      children: children,
+    return buildStyledSpan(
+      const TextStyle(fontStyle: FontStyle.italic),
+      node.children,
     );
   }
 
   InlineSpan _buildStrike(StrikeNode node) {
-    final children = buildNodes(node.children);
-    return TextSpan(
-      style: const TextStyle(decoration: TextDecoration.lineThrough),
-      children: children,
+    return buildStyledSpan(
+      const TextStyle(decoration: TextDecoration.lineThrough),
+      node.children,
     );
   }
 
   InlineSpan _buildSmall(SmallNode node) {
-    final children = buildNodes(node.children);
     final baseFontSize = config.baseTextStyle?.fontSize ?? 14;
     final baseColor = config.baseTextStyle?.color;
 
-    return TextSpan(
-      style: TextStyle(
+    return buildStyledSpan(
+      TextStyle(
         fontSize: baseFontSize * 0.8,
         color: baseColor?.withValues(alpha: 0.7),
       ),
-      children: children,
+      node.children,
     );
   }
 
   InlineSpan _buildQuote(QuoteNode node) {
-    final children = _withDisableNyaize().buildNodes(node.children);
     final baseColor = config.baseTextStyle?.color;
+    final quoteBuilder = _withDisableNyaize().withStyle(
+      TextStyle(color: baseColor?.withValues(alpha: 0.7)),
+    );
+    final children = quoteBuilder.buildNodes(node.children);
 
     return WidgetSpan(
       child: Container(
@@ -137,15 +179,7 @@ class MfmNodeBuilder {
             ),
           ),
         ),
-        child: RichText(
-          text: TextSpan(
-            // baseTextStyleをベースにしてcolorのみ上書き
-            style: config.baseTextStyle?.copyWith(
-              color: baseColor?.withValues(alpha: 0.7),
-            ),
-            children: children,
-          ),
-        ),
+        child: quoteBuilder.buildInlineRichText(children),
       ),
     );
   }
@@ -155,13 +189,7 @@ class MfmNodeBuilder {
     return WidgetSpan(
       child: SizedBox(
         width: double.infinity,
-        child: RichText(
-          textAlign: TextAlign.center,
-          text: TextSpan(
-            style: config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: buildInlineRichText(children, textAlign: TextAlign.center),
       ),
     );
   }
@@ -274,14 +302,13 @@ class MfmNodeBuilder {
   }
 
   InlineSpan _buildLink(LinkNode node) {
-    final children = _withDisableNyaize().buildNodes(node.children);
     final onLinkTap = config.onLinkTap;
-    return TextSpan(
-      style: const TextStyle(
+    return _withDisableNyaize().buildStyledSpan(
+      const TextStyle(
         color: Color(0xFF0066CC),
         decoration: TextDecoration.underline,
       ),
-      children: children,
+      node.children,
       recognizer: onLinkTap == null
           ? null
           : (TapGestureRecognizer()..onTap = () => onLinkTap(node.url)),

--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -107,13 +107,11 @@ class MfmFnHandler {
     final newScale = builder.scale * effectiveMultiplier;
 
     final scaledBuilder = builder.withScale(newScale);
-    final children = scaledBuilder.buildNodes(node.children);
-
     final baseSize = builder.config.baseTextStyle?.fontSize ?? 14.0;
 
-    return TextSpan(
-      style: TextStyle(fontSize: baseSize * effectiveMultiplier),
-      children: children,
+    return scaledBuilder.buildStyledSpan(
+      TextStyle(fontSize: baseSize * effectiveMultiplier),
+      node.children,
     );
   }
 
@@ -131,12 +129,7 @@ class MfmFnHandler {
       child: Transform(
         alignment: Alignment.center,
         transform: Matrix4.diagonal3Values(scaleX, scaleY, 1),
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -161,12 +154,7 @@ class MfmFnHandler {
     return WidgetSpan(
       child: Transform.rotate(
         angle: radians,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -208,12 +196,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -240,12 +223,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -272,12 +250,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -301,12 +274,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -317,12 +285,7 @@ class MfmFnHandler {
     return WidgetSpan(
       child: MfmSparkleWidget(
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -349,12 +312,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -381,12 +339,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -405,12 +358,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation && duration > Duration.zero,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -437,12 +385,7 @@ class MfmFnHandler {
         duration: duration,
         delay: delay,
         enabled: builder.config.enableAnimation,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -481,12 +424,7 @@ class MfmFnHandler {
       child: Transform.scale(
         scaleX: scaleX,
         scaleY: scaleY,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: scaledBuilder.buildInlineRichText(children),
       ),
     );
   }
@@ -531,12 +469,7 @@ class MfmFnHandler {
     return WidgetSpan(
       child: Transform.translate(
         offset: Offset(offsetX, offsetY),
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -565,16 +498,12 @@ class MfmFnHandler {
 
   static InlineSpan _buildFg(FnNode node, MfmNodeBuilder builder) {
     final color = _parseColorArg(node.args);
-    final children = builder.buildNodes(node.children);
 
     if (color == null) {
-      return TextSpan(children: children);
+      return TextSpan(children: builder.buildNodes(node.children));
     }
 
-    return TextSpan(
-      style: TextStyle(color: color),
-      children: children,
-    );
+    return builder.buildStyledSpan(TextStyle(color: color), node.children);
   }
 
   static InlineSpan _buildBg(FnNode node, MfmNodeBuilder builder) {
@@ -588,12 +517,7 @@ class MfmFnHandler {
     return WidgetSpan(
       child: ColoredBox(
         color: color,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -652,19 +576,13 @@ class MfmFnHandler {
           borderRadius: radius > 0 ? BorderRadius.circular(radius) : null,
         ),
         clipBehavior: noclip ? Clip.none : Clip.antiAlias,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
 
   static InlineSpan _buildFont(FnNode node, MfmNodeBuilder builder) {
     final args = node.args;
-    final children = builder.buildNodes(node.children);
 
     // フォントタイプを特定
     String? fontType;
@@ -683,15 +601,15 @@ class MfmFnHandler {
     }
 
     if (fontType == null) {
-      return TextSpan(children: children);
+      return TextSpan(children: builder.buildNodes(node.children));
     }
 
     // カスタムリゾルバーがあればそれを使用
     final customFont = builder.config.fontFamilyResolver?.call(fontType);
     if (customFont != null) {
-      return TextSpan(
-        style: TextStyle(fontFamily: customFont),
-        children: children,
+      return builder.buildStyledSpan(
+        TextStyle(fontFamily: customFont),
+        node.children,
       );
     }
 
@@ -718,10 +636,10 @@ class MfmFnHandler {
         );
       default:
         // emoji, mathはデフォルトフォント
-        return TextSpan(children: children);
+        return TextSpan(children: builder.buildNodes(node.children));
     }
 
-    return TextSpan(style: style, children: children);
+    return builder.buildStyledSpan(style, node.children);
   }
 
   static InlineSpan _buildBlur(FnNode node, MfmNodeBuilder builder) {
@@ -731,8 +649,7 @@ class MfmFnHandler {
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
       child: _MfmBlurWidget(
-        children: children,
-        baseTextStyle: builder.config.baseTextStyle,
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -858,12 +775,7 @@ class MfmFnHandler {
           onClickableEvent(eventId);
         },
         behavior: HitTestBehavior.opaque,
-        child: RichText(
-          text: TextSpan(
-            style: builder.config.baseTextStyle,
-            children: children,
-          ),
-        ),
+        child: builder.buildInlineRichText(children),
       ),
     );
   }
@@ -1061,13 +973,9 @@ class _RenderRubyText extends RenderBox {
 }
 
 class _MfmBlurWidget extends StatefulWidget {
-  const _MfmBlurWidget({
-    required this.children,
-    this.baseTextStyle,
-  });
+  const _MfmBlurWidget({required this.child});
 
-  final List<InlineSpan> children;
-  final TextStyle? baseTextStyle;
+  final Widget child;
 
   @override
   State<_MfmBlurWidget> createState() => _MfmBlurWidgetState();
@@ -1126,12 +1034,7 @@ class _MfmBlurWidgetState extends State<_MfmBlurWidget> {
             imageFilter: ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
             child: child,
           ),
-          child: RichText(
-            text: TextSpan(
-              style: widget.baseTextStyle,
-              children: widget.children,
-            ),
-          ),
+          child: widget.child,
         ),
       ),
     );

--- a/lib/src/mfm_text.dart
+++ b/lib/src/mfm_text.dart
@@ -45,24 +45,25 @@ class MfmText extends StatelessWidget {
     // brightnessを判定
     final brightness = MediaQuery.platformBrightnessOf(context);
 
+    // 明示スタイルは環境とマージせず、未指定のフォントサイズのみ補完する
+    final rawStyle =
+        mergedConfig.baseTextStyle ?? DefaultTextStyle.of(context).style;
+    final rootStyle = rawStyle.copyWith(fontSize: rawStyle.fontSize ?? 14.0);
+
     // baseTextStyleとbrightnessを設定
-    final effectiveConfig =
-        mergedConfig.baseTextStyle == null ||
-            mergedConfig.brightness == null ||
-            mergedConfig.searchButtonLabel == null
-        ? mergedConfig.copyWith(
-            baseTextStyle:
-                mergedConfig.baseTextStyle ??
-                DefaultTextStyle.of(context).style,
-            brightness: mergedConfig.brightness ?? brightness,
-            searchButtonLabel:
-                mergedConfig.searchButtonLabel ??
-                _resolveSearchButtonLabel(Localizations.maybeLocaleOf(context)),
-          )
-        : mergedConfig;
+    final effectiveConfig = mergedConfig.copyWith(
+      baseTextStyle: rootStyle,
+      brightness: mergedConfig.brightness ?? brightness,
+      searchButtonLabel:
+          mergedConfig.searchButtonLabel ??
+          _resolveSearchButtonLabel(Localizations.maybeLocaleOf(context)),
+    );
 
     // ビルダーを作成
-    final builder = MfmNodeBuilder(config: effectiveConfig);
+    final builder = MfmNodeBuilder(
+      config: effectiveConfig,
+      effectiveStyle: rootStyle,
+    );
 
     // ノードをスパンに変換
     final spans = builder.buildNodes(nodes);
@@ -70,7 +71,7 @@ class MfmText extends StatelessWidget {
     // RichTextでレンダリング
     return RichText(
       text: TextSpan(
-        style: effectiveConfig.baseTextStyle,
+        style: rootStyle,
         children: spans,
       ),
     );

--- a/test/widget/mfm_fn_test.dart
+++ b/test/widget/mfm_fn_test.dart
@@ -5,8 +5,365 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:misskey_mfm_parser/misskey_mfm_parser.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_jump_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_shake_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_spin_widget.dart';
 
 void main() {
+  group('MfmText WidgetSpan境界のスタイル継承', () {
+    const baseStyle = TextStyle(fontSize: 14, color: Colors.blue);
+    final styleCases = [
+      (
+        name: '斜体',
+        text: r'<i>$[spin abc]</i>',
+        patch: const TextStyle(fontStyle: FontStyle.italic),
+      ),
+      (
+        name: '取り消し線',
+        text: r'~~$[spin abc]~~',
+        patch: const TextStyle(decoration: TextDecoration.lineThrough),
+      ),
+      (
+        name: 'smallのルート基準サイズとalpha',
+        text: r'<small>$[spin abc]</small>',
+        patch: TextStyle(
+          fontSize: 14 * 0.8,
+          color: Colors.blue.withValues(alpha: 0.7),
+        ),
+      ),
+      (
+        name: '標準フォント',
+        text: r'$[font.monospace $[spin abc]]',
+        patch: const TextStyle(
+          fontFamily: 'Courier',
+          fontFamilyFallback: ['Courier New', 'monospace'],
+        ),
+      ),
+      (
+        name: 'カスタムフォント',
+        text: r'$[font.serif $[spin abc]]',
+        patch: const TextStyle(fontFamily: 'CustomSerif'),
+      ),
+    ];
+    for (final styleCase in styleCases) {
+      testWidgets('${styleCase.name}の差分をspin配下へ引き継ぐ', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MfmText(
+                text: styleCase.text,
+                config: MfmRenderConfig(
+                  baseTextStyle: baseStyle,
+                  fontFamilyResolver: (type) =>
+                      type == 'serif' ? 'CustomSerif' : null,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final richText = tester.widget<RichText>(
+          find.descendant(
+            of: find.byType(MfmSpinWidget),
+            matching: find.byType(RichText),
+          ),
+        );
+        expect(richText.text.style, baseStyle.merge(styleCase.patch));
+      });
+    }
+
+    testWidgets('リンクからscaleとサイズ関数を経てもスタイルとnyaize抑止を維持する', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text:
+                  r'**[$[scale.x=2,y=2 $[x2 $[spin な]]]](https://example.com)**',
+              config: MfmRenderConfig(
+                baseTextStyle: baseStyle,
+                enableNyaize: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmSpinWidget),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(richText.text.style?.fontWeight, FontWeight.bold);
+      expect(richText.text.style?.color, const Color(0xFF0066CC));
+      expect(richText.text.style?.decoration, TextDecoration.underline);
+      // scale=2の文脈でx2の倍率は1.5。ルート基準の計算式は変更しない。
+      expect(richText.text.style?.fontSize, 21);
+      expect(richText.text.toPlainText(), 'な');
+    });
+
+    testWidgets('太字をspin配下のRichTextへ引き継ぐ', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'**$[spin abc]**',
+              config: MfmRenderConfig(
+                baseTextStyle: TextStyle(fontSize: 14),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmSpinWidget),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(richText.text.style?.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('x2のフォントサイズをshake配下のRichTextへ引き継ぐ', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'$[x2 $[shake abc]]',
+              config: MfmRenderConfig(
+                baseTextStyle: TextStyle(fontSize: 14),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmShakeWidget),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(richText.text.style?.fontSize, 28);
+    });
+
+    testWidgets('前景色をjump配下のRichTextへ引き継ぐ', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(text: r'$[fg.color=f00 $[jump abc]]'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmJumpWidget),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(richText.text.style?.color, const Color(0xFFFF0000));
+    });
+
+    testWidgets('太字が兄弟のspinへ漏れない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'**abc** $[spin def]',
+              config: MfmRenderConfig(
+                baseTextStyle: TextStyle(fontSize: 14),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmSpinWidget),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(richText.text.style?.fontWeight, isNull);
+      expect(richText.text.toPlainText(), 'def');
+    });
+
+    testWidgets('baseTextStyle未指定で環境のfontSizeがnullでも描画できる', (tester) async {
+      await tester.pumpWidget(
+        const MediaQuery(
+          data: MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: DefaultTextStyle(
+              style: TextStyle(color: Colors.black),
+              child: MfmText(text: r'$[spin abc]'),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      final root = tester.widget<RichText>(
+        find
+            .descendant(
+              of: find.byType(MfmText),
+              matching: find.byType(RichText),
+            )
+            .first,
+      );
+      expect(root.text.style?.fontSize, 14);
+      final inner = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmSpinWidget),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(inner.text.style, root.text.style);
+    });
+
+    testWidgets('inheritがfalseの明示スタイルでもfontSizeを補完し環境とはマージしない', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DefaultTextStyle(
+              style: TextStyle(fontSize: 40, fontWeight: FontWeight.bold),
+              child: MfmText(
+                text: r'$[spin abc]',
+                config: MfmRenderConfig(
+                  baseTextStyle: TextStyle(inherit: false, color: Colors.red),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      final richTexts = tester.widgetList<RichText>(
+        find.descendant(
+          of: find.byType(MfmText),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(richTexts, hasLength(2));
+      for (final richText in richTexts) {
+        expect(richText.text.style?.fontSize, 14);
+        expect(richText.text.style?.fontWeight, isNull);
+        expect(richText.text.style?.color, Colors.red);
+        expect(richText.text.style?.inherit, isFalse);
+      }
+    });
+
+    testWidgets('center内側のRichTextに実効スタイルを設定する', (tester) async {
+      const baseStyle = TextStyle(fontSize: 20, color: Colors.blue);
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '<center>**abc**</center>',
+              config: MfmRenderConfig(baseTextStyle: baseStyle),
+            ),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmText),
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is RichText && widget.textAlign == TextAlign.center,
+          ),
+        ),
+      );
+      expect(richText.text.style, baseStyle);
+      expect(
+        _findSpanWithStyle(
+          richText.text as TextSpan,
+          (style) => style?.fontWeight == FontWeight.bold,
+        ),
+        isNotNull,
+      );
+    });
+
+    testWidgets('引用内側のRichTextに引用色と実効フォントサイズを設定する', (tester) async {
+      const baseStyle = TextStyle(fontSize: 20, color: Colors.blue);
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: '> **abc**',
+              config: MfmRenderConfig(baseTextStyle: baseStyle),
+            ),
+          ),
+        ),
+      );
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.descendant(
+            of: find.byType(MfmText),
+            matching: find.byType(Container),
+          ),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(
+        richText.text.style,
+        baseStyle.copyWith(color: Colors.blue.withValues(alpha: 0.7)),
+      );
+      expect(
+        _findSpanWithStyle(
+          richText.text as TextSpan,
+          (style) => style?.fontWeight == FontWeight.bold,
+        ),
+        isNotNull,
+      );
+    });
+
+    testWidgets('引用色と太字をさらに内側のspinへ伝播しnyaize抑止も維持する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MfmText(
+              text: r'> **$[x2 $[spin な]]**',
+              config: MfmRenderConfig(
+                baseTextStyle: TextStyle(fontSize: 14, color: Colors.blue),
+                enableNyaize: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final richText = tester.widget<RichText>(
+        find.descendant(
+          of: find.byType(MfmSpinWidget),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(richText.text.style?.color, Colors.blue.withValues(alpha: 0.7));
+      expect(richText.text.style?.fontWeight, FontWeight.bold);
+      expect(richText.text.style?.fontSize, 28);
+      expect(richText.text.toPlainText(), 'な');
+    });
+  });
+
   group('MfmText fn size関数', () {
     testWidgets('x2で2倍のフォントサイズになる', (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## 概要

fn の多くが `WidgetSpan` 内で `RichText(style: config.baseTextStyle)` を組み直しているため、囲っている `TextSpan` から継承すべき太字・色・フォントサイズが境界で失われる問題を修正します。#31 / #38 / #54 / #43 / #47 などの前提となる根本対応です。

## 変更内容

- `MfmNodeBuilder` に祖先の差分スタイルを反映した非 null の `effectiveStyle` を追加し、`withStyle` / `withScale` / nyaize 抑止を共通のコピー処理で扱う
- 差分スタイルを `TextSpan.style` と派生ビルダーの両方へ渡す `buildStyledSpan` を追加し、bold / italic / strike / small / link / fg / font / x2〜x4 を「差分確定 → 派生ビルダーで子を構築」の順序に変更
- `WidgetSpan` 内側の `RichText` を実効スタイルで組む `buildInlineRichText` を追加し、flip / rotate / scale / position / bg / border / clickable / 全アニメーション fn / quote / center へ適用
- quote は引用色を反映したビルダーで子と内側 `RichText` の両方を構築し、引用内のアニメーションでも色が維持されるようにする
- blur は構築済みの `Widget child` を受け取る形にし、内部での `RichText` 再生成を廃止
- `MfmText` でルートスタイルの `fontSize` を正規化（未指定時 14）し、config・ビルダー・ルート `RichText` で同一のスタイルを共有
- `**$[spin abc]**` / `$[x2 $[shake abc]]` / `$[fg.color=f00 $[jump abc]]` の3症状に加え、兄弟への漏れ防止・fontSize 補完・引用・リンク・`inherit: false` の回帰テストを追加

## スコープ外（後続PRで対応）

x2〜x4 の倍率計算式（#31）、`<small>` の計算式（#38）、`WidgetSpan` の baseline（#41）、tada の実サイズ化（#43）、textScaler の伝播は本PRでは変更していません。既存テストの期待値も変更していません。

## 検証

- `flutter test`（289件成功）
- `flutter analyze --fatal-infos`（No issues found）
- `git diff --check`

CI の `Flutter stable` ジョブは #72 の修正がマージされるまで既存の analyzer 警告で失敗します。

Closes #30
