### PR TITLE
enableAdvancedMfmをサイズ・scale・全アニメーションの共通ゲートにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `enableAdvancedMfm` の効果範囲をx2/x3/x4の視覚的拡大、scale/position、全9種類のMFMアニメーションへ拡大。`MfmRenderConfig.useAnimation`（`enableAdvancedMfm && enableAnimation`）を追加し、advanced無効時はアニメーションも停止する。既定値は両フラグともtrueを維持する（#37）。
+- advanced無効時もx2/x3/x4の公称倍率2/3/4は絵文字の描画文脈へ伝播するが、scale fnの変形・倍率伝播は停止する。アニメーション無効時は専用アニメーションwidgetを生成せず、tadaの150%フォントサイズ、rainbowの静的グラデーション、sparkleの素の子要素を維持する（#37）。
 - **Breaking:** `emojiBuilder` / `unicodeEmojiBuilder` を `Widget Function(String, MfmEmojiContext)` に変更し、実効フォントサイズと累積スケールを渡すようにした（#47、#57）。
 - **Breaking:** `MfmEmojiConfig.createDefault` / `fromResolver` の `emojiSize` の既定値を24px固定から実効フォントサイズの2倍（2em、引数はnull）に変更。固定サイズを維持する場合は `emojiSize: 24` を明示する（#47）。
 - 絵文字の `WidgetSpan` をalphabeticベースライン揃えに変更。`MfmEmojiConfig` は `MfmCustomEmoji.baselineOffset` に本家のカスタム絵文字と同じ `vertical-align: middle` 相当の下降量（`size / 2 - フォントサイズ × 0.25`）を設定し、行の下降量にも反映する。Unicode絵文字を画像で描画する場合は高さ1.25em・下降量 `フォントサイズ × 0.25`（`vertical-align: -0.25em` 相当）を指定する（#57）。

--- a/README.ja.md
+++ b/README.ja.md
@@ -85,6 +85,11 @@ Misskeyの猫モードと同等の挙動で、テキストノードの文字列�
 サイズ関数・`tada`・`<small>` は実効フォントサイズを変更します。`scale` は
 フォントサイズを変更せず描画時の変形として適用されるため、高さに
 `context.scale` を重ねて掛けないでください。
+x2/x3/x4の視覚的拡大と `scale` の効果には `enableAdvancedMfm: true` が必要です。
+falseの場合、x2/x3/x4はフォントサイズを変えませんが、公称倍率2/3/4は
+`context.scale` へ伝播します。`scale` は変形も文脈への倍率伝播も行いません。
+例えば基準14pxの `$[x4 :emoji:]` の高さは28pxのままで、描画文脈は
+`(fontSize: 14, scale: 4)` になります。
 
 カスタム絵文字の幅は既定で元画像の比率に従います。極端に横長な絵文字の幅を
 制限する場合は、`MfmEmojiConfig` の `emojiMaxWidth` または
@@ -403,14 +408,19 @@ MfmCustomEmoji(
 - `fontSize`: サイズ関数・`tada`（150%）・`<small>`（80%）を反映した
   現在の実効フォントサイズ（論理px）。
 - `scale`: x2/x3/x4/scale関数の累積倍率。`tada` と `<small>` では変わりません。
-  基準14pxなら、x2は `(28, 2)`、x4は `(84, 6)`、`scale.x=3,y=3` は
-  `(14, 3)`、`tada` は `(21, 1)` です。非等倍の `scale` は本家と同じく
-  `max(x, y)` を掛けるため、`scale.x=3,y=1` も `(14, 3)` になります。
+  advanced MFMが有効で基準14pxなら、x2は `(28, 2)`、x4は `(84, 4)`、
+  `scale.x=3,y=3` は `(14, 3)`、`tada` は `(21, 1)` です。
+  非等倍の `scale` は非負の値では本家と同じく `max(x, y)` を掛けるため、
+  `scale.x=3,y=1` も `(14, 3)` になります。`enableAdvancedMfm: false` では、
+  x2/x3/x4は `(14, 2)` / `(14, 3)` / `(14, 4)`、`scale.x=3,y=3` は
+  `(14, 1)` になります。
 - `useOriginalSize`: 本家と同じ `scale >= 2.5` による原寸画像利用のヒント。
   `misskey_emoji` 2.0.0-beta.1 は `EmojiImage.url` を1つだけ公開し、原寸／縮小版を
   区別しません。自動切替には依存パッケージ側の対応が必要なため、現時点では
   `MfmCustomEmoji.useOriginalSize` は追加していません。両URLを取得できる
-  独自ビルダーでこのヒントを利用できます。
+  独自ビルダーでこのヒントを利用できます。advanced MFM無効時もx系の倍率は
+  伝播するため、`$[x4 :emoji:]` はフォントを拡大しなくても
+  `useOriginalSize: true` になり得ます。
 
 両ビルダーの結果は `WidgetSpan` のalphabeticベースラインに揃えます。
 任意のWidgetの画像高さ・下降量はレンダラーから判断できないため、ベースラインは
@@ -509,17 +519,34 @@ MfmText(
 
 ### 高度なMFMの制御
 
-`position` などの高度なfn関数はセキュリティ上の理由から制御できます。  
+`enableAdvancedMfm` はx2/x3/x4の視覚的拡大、`scale`、`position`、
+および全9種類のMFMアニメーション関数を制御します。アニメーションは両フラグが
+trueのときだけ有効です。読み取り専用の `config.useAnimation` ゲッターは
+`enableAdvancedMfm && enableAnimation` を返します。既定値は両方trueです。
 
 ```dart
 MfmText(
-  text: r'$[position.x=10 移動]',
+  text: r'$[x4 拡大] $[scale.x=3 変形] $[position.x=10 移動] $[spin 静止]',
   config: MfmRenderConfig(
-    // positionなどの高度な機能を無効化
+    // サイズ・scale・positionの効果とMFMアニメーションを抑止
     enableAdvancedMfm: false,
+    enableAnimation: true, // advanced MFMの設定が優先される
   ),
 )
 ```
+
+advanced MFM無効時、x2/x3/x4はフォントサイズを維持します（絵文字の描画文脈への
+公称倍率伝播は継続）。`scale` は変形も倍率伝播も行わず、`position` は
+`$[position 子要素]` としてリテラル表示されます。`flip`、`rotate`、その他の
+スタイル関数は引き続き利用できます。
+
+どちらかのフラグがfalseの場合、`spin`、`jump`、`bounce`、`shake`、`twitch`、
+`jelly` はアニメーション用ラッパーなしで子要素を表示します。`tada` は150%の
+フォントサイズを維持し、`rainbow` は静的グラデーション、`sparkle` はラッパーなしの
+子要素になります。サイズ・scale・positionの効果を維持してMFMアニメーションだけを
+止める場合は、`enableAnimation: false` のみを指定してください。
+これらのフラグはMFMアニメーション関数を制御し、アニメーション絵文字画像の再生は
+制御しません。OSの「視差効果を減らす」設定には自動連動しません。
 
 ### unixtime のローカライズ
 
@@ -545,8 +572,9 @@ void main() {
 | プロパティ | 型 | デフォルト | 説明 |
 |-----------|------|---------|------|
 | `baseTextStyle` | `TextStyle?` | null | ベースのテキストスタイル |
-| `enableAdvancedMfm` | `bool` | true | position等の高度な機能を有効化 |
-| `enableAnimation` | `bool` | true | アニメーションを有効化（今後実装） |
+| `enableAdvancedMfm` | `bool` | true | x2/x3/x4の視覚的拡大、scale/positionの効果、MFMアニメーションを有効化 |
+| `enableAnimation` | `bool` | true | advanced MFM有効時のMFMアニメーションを有効化 |
+| `useAnimation` | `bool`（getter） | true（導出値） | 読み取り専用の実効判定: `enableAdvancedMfm && enableAnimation` |
 | `enableNyaize` | `bool` | false | nyaize（猫語）変換をテキストノードに対して有効化 |
 | `emojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | カスタム絵文字ビルダー |
 | `unicodeEmojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | Unicode絵文字ビルダー |
@@ -578,16 +606,26 @@ void main() {
 ### スケールの制限
 
 `scale` fn関数は最大5倍に制限されています。これはMisskey本家と同様の制限です。
+`enableAdvancedMfm: false` の場合、描画時の変形も `MfmEmojiContext.scale` への
+倍率伝播も行いません。外側のx系関数から継承した倍率はそのまま維持します。
+静的な子要素には `TextSpan` を使い、本家の空の `inline-block` spanによる
+行レイアウトの境界までは再現しません。
 
 ### サイズ関数の入れ子
 
-`x2`、`x3`、`x4`は、異なる種類の組み合わせも含めて共通のネスト深さを使い、Misskey本家と同じ動作をします。以下の割合はいずれも親の実効フォントサイズに対する相対値です。
+`x2`、`x3`、`x4`は、異なる種類の組み合わせも含めて共通のネスト深さを使い、Misskey本家と同じ動作をします。advanced MFM有効時、以下の割合はいずれも親の実効フォントサイズに対する相対値です。
 
 - 1階層目: `x2`は200%、`x3`は400%、`x4`は600%。
 - 2階層目: 内側の関数自身のzoom値を使い、`zoom / 2 + 50%`（`x2`: 150%、`x3`: 250%、`x4`: 350%）。
 - 3階層目以降: 100%（追加の拡大を無効化し、親のフォントサイズを継承）。
 
 ベースフォントサイズが14pxの場合、`$[x2 $[x2 A]]`の外側は28px、内側は42pxになります。`$[x2 $[x3 A]]`の内側は70pxです。3階層目にサイズ関数を追加しても、それ以上は拡大しません。太字、アニメーション関数、`scale`など他のノードは、このネスト深さを増やさずに引き継ぎます。
+
+`enableAdvancedMfm: false` の場合、x2/x3/x4はどの階層でもフォントサイズを
+変更しません。ネスト深さと公称倍率（2/3/4）は、3階層目以降も伝播します。
+この倍率はCSSのフォントサイズ割合とは別系統です。例えば `$[x2 $[x3 A]]` は
+基準14pxのままですが、子要素へ渡すscaleは6です。`enableAnimation` だけを
+無効化しても、サイズ関数の動作は変わりません。
 
 ## 追加情報
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ an explicit fixed height. The low-level `MfmCustomEmoji.size` default remains
 24px when constructed directly. Size functions, `tada`, and `<small>` adjust
 the effective font size; `scale` applies its existing paint transform without
 changing that font size (do not multiply the height by `context.scale` again).
+Visual x2/x3/x4 enlargement and `scale` effects require `enableAdvancedMfm: true`.
+When it is false, x2/x3/x4 keep the font size unchanged but still propagate
+nominal `context.scale` multipliers of 2/3/4; `scale` applies neither a transform
+nor a context multiplier. For example, `$[x4 :emoji:]` stays 28px high at a 14px
+base font, while its context is `(fontSize: 14, scale: 4)`.
 
 Custom emojis use their natural width by default. To cap very wide emojis,
 pass `emojiMaxWidth` to `MfmEmojiConfig` or `maxWidth` to `MfmCustomEmoji`.
@@ -406,14 +411,18 @@ widget). The publicly exported immutable `MfmEmojiContext` contains:
   size functions, `tada` (150%), and `<small>` (80%).
 - `scale`: the cumulative x2/x3/x4/scale-function multiplier. `tada` and
   `<small>` do not change it. For a 14px base, x2 gives `(28, 2)`, x4 gives
-  `(84, 6)`, `scale.x=3,y=3` gives `(14, 3)`, and `tada` gives `(21, 1)`.
-  A non-uniform `scale` multiplies by `max(x, y)`, matching Misskey, so
-  `scale.x=3,y=1` also gives `(14, 3)`.
+  `(84, 4)`, `scale.x=3,y=3` gives `(14, 3)`, and `tada` gives `(21, 1)`
+  with advanced MFM enabled. A non-uniform `scale` multiplies by `max(x, y)`
+  for non-negative values, matching Misskey, so `scale.x=3,y=1` also gives
+  `(14, 3)`. With `enableAdvancedMfm: false`, x2/x3/x4 instead give
+  `(14, 2)` / `(14, 3)` / `(14, 4)`, while `scale.x=3,y=3` gives `(14, 1)`.
 - `useOriginalSize`: `scale >= 2.5`, matching Misskey's original-image hint.
   `misskey_emoji` 2.0.0-beta.1 exposes only one `EmojiImage.url`, with no
   original/thumbnail distinction. Automatic original-URL switching requires
   support in that dependency; no `MfmCustomEmoji.useOriginalSize` option is
   provided yet. A custom builder with access to both URLs can use the hint.
+  Because x multipliers still propagate with advanced MFM disabled,
+  `$[x4 :emoji:]` can have `useOriginalSize: true` without enlarging the font.
 
 Both builder results use an alphabetic-baseline `WidgetSpan`. The renderer
 cannot infer an arbitrary widget's image height or descent; the builder must
@@ -514,17 +523,34 @@ The default colors are based on Misskey's official implementation:
 
 ### Advanced MFM Control
 
-Control advanced fn functions like `position` for security reasons:
+`enableAdvancedMfm` controls the visual enlargement of x2/x3/x4, `scale`,
+`position`, and all nine MFM animation functions. Animations run only when
+both flags are true: the read-only `config.useAnimation` getter is
+`enableAdvancedMfm && enableAnimation`. Both flags default to true.
 
 ```dart
 MfmText(
-  text: r'$[position.x=10 moved]',
+  text: r'$[x4 large] $[scale.x=3 scaled] $[position.x=10 moved] $[spin still]',
   config: MfmRenderConfig(
-    // Disable advanced features like position
+    // Suppress size/scale/position effects and MFM animations
     enableAdvancedMfm: false,
+    enableAnimation: true, // Advanced MFM takes precedence
   ),
 )
 ```
+
+With advanced MFM disabled, x2/x3/x4 preserve font size (but still propagate
+nominal emoji-context scale), `scale` applies neither a transform nor scale
+propagation, and `position` is rendered literally as `$[position children]`.
+`flip`, `rotate`, and other styling functions remain available.
+
+When either flag is false, `spin`, `jump`, `bounce`, `shake`, `twitch`, and
+`jelly` render their children without animation wrappers. `tada` retains its
+150% font size, `rainbow` uses a static gradient, and `sparkle` renders its
+children without a wrapper. Set only `enableAnimation: false` to stop MFM
+animations while keeping size, scale, and position effects.
+These flags control MFM animation functions, not playback of animated emoji
+images. They do not automatically follow the OS reduced-motion preference.
 
 ### Localizing unixtime
 
@@ -549,8 +575,9 @@ void main() {
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `baseTextStyle` | `TextStyle?` | null | Base text style |
-| `enableAdvancedMfm` | `bool` | true | Enable advanced features like position |
-| `enableAnimation` | `bool` | true | Enable animations (for future use) |
+| `enableAdvancedMfm` | `bool` | true | Enable visual x2/x3/x4 enlargement, scale/position effects, and MFM animations |
+| `enableAnimation` | `bool` | true | Enable MFM animations when advanced MFM is enabled |
+| `useAnimation` | `bool` (getter) | true (derived) | Read-only effective animation gate: `enableAdvancedMfm && enableAnimation` |
 | `enableNyaize` | `bool` | false | Enable nyaize (cat-speak) transformation on text nodes |
 | `emojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | Custom emoji builder |
 | `unicodeEmojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | Unicode emoji builder |
@@ -581,16 +608,26 @@ This library prioritizes visual fidelity and does not support text selection aft
 ### Scale Limits
 
 The `scale` fn function is limited to a maximum of 5x. This is the same security limitation as Misskey's official implementation.
+With `enableAdvancedMfm: false`, it applies neither a paint transform nor a
+multiplier to `MfmEmojiContext.scale`; any scale inherited from an outer x
+function is preserved. Its static children use `TextSpan`, without reproducing
+the upstream empty `inline-block` span's line-layout boundary.
 
 ### Nested Size Functions
 
-The `x2`, `x3`, and `x4` functions share a nesting depth, including mixed combinations, matching Misskey's official behavior. All percentages are relative to the parent's effective font size:
+The `x2`, `x3`, and `x4` functions share a nesting depth, including mixed combinations, matching Misskey's official behavior. With advanced MFM enabled, all percentages are relative to the parent's effective font size:
 
 - First level: `x2` is 200%, `x3` is 400%, and `x4` is 600%.
 - Second level: `zoom / 2 + 50%`, using the inner function's zoom value (`x2`: 150%, `x3`: 250%, `x4`: 350%).
 - Third level and deeper: 100% (no further enlargement; the parent's font size is inherited).
 
 For a base font size of 14px, `$[x2 $[x2 A]]` renders the outer level at 28px and the inner level at 42px. `$[x2 $[x3 A]]` renders the inner level at 70px. Adding a third size function does not enlarge it further. Other nodes, such as bold, animation functions, and `scale`, preserve this nesting depth without increasing it.
+
+With `enableAdvancedMfm: false`, x2/x3/x4 do not change font size at any depth.
+Nesting depth and nominal scale multipliers (2/3/4) still propagate, even at the
+third level and deeper. These multipliers are separate from the CSS font-size
+percentages: `$[x2 $[x3 A]]` keeps a 14px base font but passes scale 6 to its
+children. Disabling only `enableAnimation` does not change size-function behavior.
 
 ## Additional information
 

--- a/lib/src/config/mfm_render_config.dart
+++ b/lib/src/config/mfm_render_config.dart
@@ -26,6 +26,8 @@ class MfmEmojiContext {
   /// x2/x3/x4/scale fnの累積倍率。tadaやsmallのサイズ変更は含まない。
   ///
   /// scale fnは描画時の変形なので、[fontSize]には反映されない。
+  /// advanced MFMが無効でもx2/x3/x4の公称倍率は伝播するが、
+  /// scale fnの倍率は伝播しない。
   final double scale;
 
   /// 本家と同じく2.5倍以上で原寸画像を使うべきか。
@@ -83,11 +85,16 @@ class MfmRenderConfig {
   /// ベースのテキストスタイル（指定しない場合はデフォルトを使用）
   final TextStyle? baseTextStyle;
 
-  /// advancedMfm（position等の高度な機能）を有効化
+  /// x2/x3/x4の視覚的サイズ変更、scale/position、MFMアニメーションを有効化。
+  ///
+  /// 無効時もx2/x3/x4の公称倍率は絵文字の描画文脈へ伝播する。
   final bool enableAdvancedMfm;
 
-  /// アニメーションを有効化（将来用）
+  /// [enableAdvancedMfm]が有効な場合のMFMアニメーションを有効化。
   final bool enableAnimation;
+
+  /// MFMアニメーションの実効的な有効判定。
+  bool get useAnimation => enableAdvancedMfm && enableAnimation;
 
   /// nyaize変換を有効化
   final bool enableNyaize;

--- a/lib/src/fn/animated/mfm_rainbow_widget.dart
+++ b/lib/src/fn/animated/mfm_rainbow_widget.dart
@@ -26,28 +26,6 @@ class MfmRainbowWidget extends StatelessWidget {
     Color(0xFFFF00FF),
   ];
 
-  static const _rainbowColors = <Color>[
-    Color(0xFFFF0000),
-    Color(0xFFFFA500),
-    Color(0xFFFFFF00),
-    Color(0xFF00FF00),
-    Color(0xFF00FFFF),
-    Color(0xFF0000FF),
-    Color(0xFFFF00FF),
-    Color(0xFFFF0000),
-  ];
-
-  static const _staticStops = <double>[
-    0,
-    0.17,
-    0.33,
-    0.5,
-    0.67,
-    0.83,
-    1,
-    1,
-  ];
-
   static const _animatedStops = <double>[
     0,
     0.14,
@@ -101,7 +79,7 @@ class MfmRainbowWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!enabled) {
-      return _buildShaderMask(child, _rainbowColors, _staticStops);
+      return MfmStaticRainbowWidget(child: child);
     }
 
     return MfmAnimatedWrapper(
@@ -113,6 +91,47 @@ class MfmRainbowWidget extends StatelessWidget {
         final colors = _buildShiftedColors(progress.value);
         return _buildShaderMask(child, colors, _animatedStops);
       },
+    );
+  }
+}
+
+class MfmStaticRainbowWidget extends StatelessWidget {
+  const MfmStaticRainbowWidget({super.key, required this.child});
+
+  final Widget child;
+
+  // 本家の_mfm_rainbow_fallback_と同じ色と停止位置。
+  static const _rainbowColors = <Color>[
+    Color(0xFFFF0000),
+    Color(0xFFFFA500),
+    Color(0xFFFFFF00),
+    Color(0xFF00FF00),
+    Color(0xFF00FFFF),
+    Color(0xFF0000FF),
+    Color(0xFFFF00FF),
+    Color(0xFFFF0000),
+  ];
+
+  static const _staticStops = <double>[
+    0,
+    0.17,
+    0.33,
+    0.5,
+    0.67,
+    0.83,
+    1,
+    1,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return ShaderMask(
+      blendMode: BlendMode.srcIn,
+      shaderCallback: (bounds) => const LinearGradient(
+        colors: _rainbowColors,
+        stops: _staticStops,
+      ).createShader(bounds),
+      child: child,
     );
   }
 }

--- a/lib/src/fn/mfm_fn_handler.dart
+++ b/lib/src/fn/mfm_fn_handler.dart
@@ -62,7 +62,7 @@ class MfmFnHandler {
       case 'clickable':
         return _buildClickable(node, builder);
 
-      // アニメーション系（将来実装）
+      // アニメーション系
       case 'tada':
         return _buildTada(node, builder);
       case 'jelly':
@@ -127,11 +127,11 @@ class MfmFnHandler {
         : depth == 1
         ? sizeMultiplier / 2 + 0.5
         : 1.0;
-    // 本家はネスト深さに関係なく公称倍率でscaleを更新する
+    // 本家はadvanced MFMの有効状態やネスト深さに関係なく公称倍率でscaleを更新する
     final sizedBuilder = builder
         .withSizeDepth(depth + 1)
         .withScale(builder.scale * nominalScale);
-    if (factor == 1.0) {
+    if (!builder.config.enableAdvancedMfm || factor == 1.0) {
       return TextSpan(children: sizedBuilder.buildNodes(node.children));
     }
 
@@ -201,7 +201,7 @@ class MfmFnHandler {
   }
 
   static InlineSpan _buildSpin(FnNode node, MfmNodeBuilder builder) {
-    if (!builder.config.enableAnimation) {
+    if (!builder.config.useAnimation) {
       return TextSpan(children: builder.buildNodes(node.children));
     }
 
@@ -238,14 +238,14 @@ class MfmFnHandler {
         direction: direction,
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.useAnimation,
         child: builder.buildInlineRichText(children),
       ),
     );
   }
 
   static InlineSpan _buildJump(FnNode node, MfmNodeBuilder builder) {
-    if (!builder.config.enableAnimation) {
+    if (!builder.config.useAnimation) {
       return TextSpan(children: builder.buildNodes(node.children));
     }
 
@@ -267,14 +267,14 @@ class MfmFnHandler {
       child: MfmJumpWidget(
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.useAnimation,
         child: builder.buildInlineRichText(children),
       ),
     );
   }
 
   static InlineSpan _buildBounce(FnNode node, MfmNodeBuilder builder) {
-    if (!builder.config.enableAnimation) {
+    if (!builder.config.useAnimation) {
       return TextSpan(children: builder.buildNodes(node.children));
     }
 
@@ -296,7 +296,7 @@ class MfmFnHandler {
       child: MfmBounceWidget(
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.useAnimation,
         child: builder.buildInlineRichText(children),
       ),
     );
@@ -312,37 +312,44 @@ class MfmFnHandler {
 
     // 本家 Misskey ではアニメーション有効時の duration=0 は
     // rainbow の静的フォールバックを適用せず、通常の文字表示になる。
-    if (builder.config.enableAnimation && duration <= Duration.zero) {
+    if (builder.config.useAnimation && duration <= Duration.zero) {
       return TextSpan(children: children);
     }
 
     return WidgetSpan(
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
-      child: MfmRainbowWidget(
-        duration: duration,
-        delay: delay,
-        enabled: builder.config.enableAnimation,
-        child: builder.buildInlineRichText(children),
-      ),
+      child: builder.config.useAnimation
+          ? MfmRainbowWidget(
+              duration: duration,
+              delay: delay,
+              enabled: builder.config.useAnimation,
+              child: builder.buildInlineRichText(children),
+            )
+          : MfmStaticRainbowWidget(
+              child: builder.buildInlineRichText(children),
+            ),
     );
   }
 
   static InlineSpan _buildSparkle(FnNode node, MfmNodeBuilder builder) {
     final children = builder.buildNodes(node.children);
+    if (!builder.config.useAnimation) {
+      return TextSpan(children: children);
+    }
 
     return WidgetSpan(
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
       child: MfmSparkleWidget(
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.useAnimation,
         child: builder.buildInlineRichText(children),
       ),
     );
   }
 
   static InlineSpan _buildShake(FnNode node, MfmNodeBuilder builder) {
-    if (!builder.config.enableAnimation) {
+    if (!builder.config.useAnimation) {
       return TextSpan(children: builder.buildNodes(node.children));
     }
 
@@ -364,14 +371,14 @@ class MfmFnHandler {
       child: MfmShakeWidget(
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.useAnimation,
         child: builder.buildInlineRichText(children),
       ),
     );
   }
 
   static InlineSpan _buildTwitch(FnNode node, MfmNodeBuilder builder) {
-    if (!builder.config.enableAnimation) {
+    if (!builder.config.useAnimation) {
       return TextSpan(children: builder.buildNodes(node.children));
     }
 
@@ -393,7 +400,7 @@ class MfmFnHandler {
       child: MfmTwitchWidget(
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.useAnimation,
         child: builder.buildInlineRichText(children),
       ),
     );
@@ -407,9 +414,13 @@ class MfmFnHandler {
     final delay = MfmAnimatedWrapper.parseTime(args['delay']) ?? Duration.zero;
 
     // 150%は描画時のTransformではなく実フォントサイズとしてレイアウトに反映する。
-    final sized = builder.withStyle(
-      TextStyle(fontSize: builder.effectiveStyle.fontSize! * 1.5),
+    final sizeStyle = TextStyle(
+      fontSize: builder.effectiveStyle.fontSize! * 1.5,
     );
+    if (!builder.config.useAnimation) {
+      return builder.buildStyledSpan(sizeStyle, node.children);
+    }
+    final sized = builder.withStyle(sizeStyle);
     final children = sized.buildNodes(node.children);
 
     return WidgetSpan(
@@ -418,14 +429,14 @@ class MfmFnHandler {
       child: MfmTadaWidget(
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation && duration > Duration.zero,
+        enabled: builder.config.useAnimation && duration > Duration.zero,
         child: sized.buildInlineRichText(children),
       ),
     );
   }
 
   static InlineSpan _buildJelly(FnNode node, MfmNodeBuilder builder) {
-    if (!builder.config.enableAnimation) {
+    if (!builder.config.useAnimation) {
       return TextSpan(children: builder.buildNodes(node.children));
     }
 
@@ -447,13 +458,17 @@ class MfmFnHandler {
       child: MfmJellyWidget(
         duration: duration,
         delay: delay,
-        enabled: builder.config.enableAnimation,
+        enabled: builder.config.useAnimation,
         child: builder.buildInlineRichText(children),
       ),
     );
   }
 
   static InlineSpan _buildScale(FnNode node, MfmNodeBuilder builder) {
+    if (!builder.config.enableAdvancedMfm) {
+      return TextSpan(children: builder.buildNodes(node.children));
+    }
+
     final args = node.args;
 
     // x, y引数を取得（デフォルト: 1.0）

--- a/test/misskey_mfm_renderer_test.dart
+++ b/test/misskey_mfm_renderer_test.dart
@@ -7,6 +7,7 @@ void main() {
       const config = MfmRenderConfig();
       expect(config.enableAdvancedMfm, true);
       expect(config.enableAnimation, true);
+      expect(config.useAnimation, true);
       expect(config.enableNyaize, false);
       expect(config.baseTextStyle, null);
       expect(config.author, null);
@@ -24,6 +25,27 @@ void main() {
       expect(localized.searchButtonLabel, isNull);
       expect(localized.useLocaleSearchButtonLabel, isTrue);
     });
+
+    for (final advanced in [false, true]) {
+      for (final animation in [false, true]) {
+        test('useAnimation is the AND of $advanced and $animation', () {
+          final config = MfmRenderConfig(
+            enableAdvancedMfm: advanced,
+            enableAnimation: animation,
+          );
+          expect(config.useAnimation, advanced && animation);
+          expect(config.copyWith().useAnimation, advanced && animation);
+          expect(
+            config.copyWith(enableAdvancedMfm: !advanced).useAnimation,
+            !advanced && animation,
+          );
+          expect(
+            config.copyWith(enableAnimation: !animation).useAnimation,
+            advanced && !animation,
+          );
+        });
+      }
+    }
 
     test('copyWith works correctly', () {
       const config = MfmRenderConfig();

--- a/test/widget/emoji_context_test.dart
+++ b/test/widget/emoji_context_test.dart
@@ -102,6 +102,57 @@ void main() {
         });
       }
 
+      final advancedDisabledCases = [
+        (text: r'$[x2 EMOJI]', fontSize: 14.0, scale: 2.0),
+        (text: r'$[x3 EMOJI]', fontSize: 14.0, scale: 3.0),
+        (text: r'$[x4 EMOJI]', fontSize: 14.0, scale: 4.0),
+        (text: r'$[x2 $[x3 $[x4 EMOJI]]]', fontSize: 14.0, scale: 24.0),
+        (text: r'$[scale.x=3,y=2 EMOJI]', fontSize: 14.0, scale: 1.0),
+        (text: r'$[x2 $[scale.x=3,y=2 EMOJI]]', fontSize: 14.0, scale: 2.0),
+        (text: r'$[scale.x=3,y=2 $[x4 EMOJI]]', fontSize: 14.0, scale: 4.0),
+        (text: r'$[tada EMOJI]', fontSize: 21.0, scale: 1.0),
+        (text: r'$[x4 $[tada EMOJI]]', fontSize: 21.0, scale: 4.0),
+      ];
+      for (final testCase in advancedDisabledCases) {
+        testWidgets('advanced無効時の描画文脈: ${testCase.text}', (tester) async {
+          final contexts = <MfmEmojiContext>[];
+          Widget buildEmoji(String name, MfmEmojiContext context) {
+            contexts.add(context);
+            return const SizedBox.square(dimension: 20);
+          }
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: MfmText(
+                  text: '${testCase.text.replaceAll('EMOJI', emoji)} $emoji',
+                  config: MfmRenderConfig(
+                    baseTextStyle: const TextStyle(fontSize: 14),
+                    enableAdvancedMfm: false,
+                    emojiBuilder: buildEmoji,
+                    unicodeEmojiBuilder: buildEmoji,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          expect(contexts, [
+            MfmEmojiContext(fontSize: testCase.fontSize, scale: testCase.scale),
+            const MfmEmojiContext(fontSize: 14, scale: 1),
+          ]);
+          expect(contexts.first.useOriginalSize, testCase.scale >= 2.5);
+          expect(
+            find.descendant(
+              of: find.byType(MfmText),
+              matching: find.byType(Transform),
+            ),
+            findsNothing,
+          );
+          expect(tester.takeException(), isNull);
+        });
+      }
+
       testWidgets('aligns the widget span to the alphabetic baseline', (
         tester,
       ) async {

--- a/test/widget/mfm_animated_test.dart
+++ b/test/widget/mfm_animated_test.dart
@@ -2,7 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:misskey_mfm_parser/misskey_mfm_parser.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_animated_wrapper.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_bounce_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_jelly_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_jump_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_rainbow_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_shake_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_sparkle_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_spin_widget.dart';
 import 'package:misskey_mfm_renderer/src/fn/animated/mfm_tada_widget.dart';
+import 'package:misskey_mfm_renderer/src/fn/animated/mfm_twitch_widget.dart';
 
 void main() {
   group('MfmText spin アニメーション', () {
@@ -465,13 +474,14 @@ void main() {
         ),
       );
 
-      final tada = find.byType(MfmTadaWidget);
-      final richText = tester.widget<RichText>(
-        find.descendant(of: tada, matching: find.byType(RichText)),
-      );
-      expect(richText.text.style?.fontSize, 21);
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(_textStyles(richText.text).single.fontSize, 21);
+      expect(find.byType(MfmTadaWidget), findsNothing);
       expect(
-        find.descendant(of: tada, matching: find.byType(Transform)),
+        find.descendant(
+          of: find.byType(MfmText),
+          matching: find.byType(Transform),
+        ),
         findsNothing,
       );
     });
@@ -492,6 +502,7 @@ void main() {
                     ),
                   ),
                   MfmText(
+                    key: ValueKey('tada'),
                     text: r'$[tada A]B',
                     config: MfmRenderConfig(
                       baseTextStyle: TextStyle(fontSize: 14),
@@ -514,7 +525,14 @@ void main() {
           )
           .height;
       // getSizeはTransformの描画倍率ではなくRenderBoxのレイアウトサイズ。
-      final tadaHeight = tester.getSize(find.byType(MfmTadaWidget)).height;
+      final tadaHeight = tester
+          .getSize(
+            find.descendant(
+              of: find.byKey(const ValueKey('tada')),
+              matching: find.byType(RichText),
+            ),
+          )
+          .height;
       expect(tadaHeight, greaterThan(plainHeight));
       expect(tadaHeight, closeTo(plainHeight * 1.5, 0.1));
     });
@@ -534,13 +552,9 @@ void main() {
         ),
       );
 
-      final richText = tester.widget<RichText>(
-        find.descendant(
-          of: find.byType(MfmTadaWidget),
-          matching: find.byType(RichText),
-        ),
-      );
-      expect(richText.text.style?.fontSize, 42);
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      expect(_textStyles(richText.text).single.fontSize, 42);
+      expect(find.byType(MfmTadaWidget), findsNothing);
     });
 
     testWidgets('tadaの子WidgetSpanにも150%の実効フォントサイズが伝わる', (tester) async {
@@ -558,16 +572,17 @@ void main() {
         ),
       );
 
-      final richTexts = tester.widgetList<RichText>(
+      final richText = tester.widget<RichText>(
         find.descendant(
-          of: find.byType(MfmTadaWidget),
+          of: find.descendant(
+            of: find.byType(MfmText),
+            matching: find.byType(Transform),
+          ),
           matching: find.byType(RichText),
         ),
       );
-      expect(richTexts, hasLength(2));
-      for (final richText in richTexts) {
-        expect(richText.text.style?.fontSize, 21);
-      }
+      expect(richText.text.style?.fontSize, 21);
+      expect(find.byType(MfmTadaWidget), findsNothing);
     });
 
     testWidgets('tadaのTransformは150%を重ねずキーフレームの倍率だけを適用する', (
@@ -771,6 +786,129 @@ void main() {
       });
       expect(hasText, isTrue);
     });
+  });
+
+  group('MfmText アニメーションの共通ゲート', () {
+    const animatedFunctions = <String, Type>{
+      'spin': MfmSpinWidget,
+      'jump': MfmJumpWidget,
+      'bounce': MfmBounceWidget,
+      'shake': MfmShakeWidget,
+      'twitch': MfmTwitchWidget,
+      'jelly': MfmJellyWidget,
+      'tada': MfmTadaWidget,
+      'rainbow': MfmRainbowWidget,
+      'sparkle': MfmSparkleWidget,
+    };
+    for (final flags in [
+      (advanced: false, animation: true),
+      (advanced: true, animation: false),
+      (advanced: false, animation: false),
+    ]) {
+      for (final fn in animatedFunctions.keys) {
+        testWidgets(
+          '$fn advanced=${flags.advanced}, animation=${flags.animation}は静的表示',
+          (tester) async {
+            await tester.pumpWidget(
+              MaterialApp(
+                home: Scaffold(
+                  body: MfmText(
+                    text: '\$[$fn **body**]',
+                    config: MfmRenderConfig(
+                      baseTextStyle: const TextStyle(fontSize: 14),
+                      enableAdvancedMfm: flags.advanced,
+                      enableAnimation: flags.animation,
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+            for (final type in animatedFunctions.values) {
+              expect(find.byType(type), findsNothing);
+            }
+            expect(find.byType(MfmAnimatedWrapper), findsNothing);
+            final richTexts = tester.widgetList<RichText>(
+              find.byType(RichText),
+            );
+            final text = richTexts.singleWhere(
+              (widget) => widget.text.toPlainText() == 'body',
+            );
+            final styles = _textStyles(text.text).toList();
+            expect(styles, hasLength(1));
+            expect(styles.single.fontSize, fn == 'tada' ? 21 : 14);
+            expect(styles.single.fontWeight, FontWeight.bold);
+            if (fn == 'rainbow') {
+              expect(richTexts, hasLength(2));
+              expect(find.byType(MfmStaticRainbowWidget), findsOneWidget);
+              expect(find.byType(ShaderMask), findsOneWidget);
+              expect(
+                tester.widget<ShaderMask>(find.byType(ShaderMask)).blendMode,
+                BlendMode.srcIn,
+              );
+            } else {
+              expect(richTexts, hasLength(1));
+              expect(find.byType(ShaderMask), findsNothing);
+              text.text.visitChildren((span) {
+                expect(span, isNot(isA<WidgetSpan>()));
+                return true;
+              });
+            }
+            await tester.pump(const Duration(seconds: 2));
+            expect(tester.binding.transientCallbackCount, 0);
+            expect(tester.takeException(), isNull);
+          },
+        );
+      }
+
+      testWidgets('rainbowの静的フォールバックはspeedより優先される $flags', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MfmText(
+                text: r'$[rainbow.speed=0s,delay=2s body]',
+                config: MfmRenderConfig(
+                  enableAdvancedMfm: flags.advanced,
+                  enableAnimation: flags.animation,
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(find.byType(MfmRainbowWidget), findsNothing);
+        expect(find.byType(MfmAnimatedWrapper), findsNothing);
+        expect(find.byType(ShaderMask), findsOneWidget);
+        await tester.pump(const Duration(seconds: 3));
+        expect(tester.binding.transientCallbackCount, 0);
+        expect(tester.takeException(), isNull);
+      });
+    }
+
+    for (final fn in animatedFunctions.entries) {
+      testWidgets('${fn.key}はadvanced切替で静的表示へ移行し再開できる', (tester) async {
+        for (final enabled in [true, false, true]) {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: MfmText(
+                  text: '\$[${fn.key} body]',
+                  config: MfmRenderConfig(enableAdvancedMfm: enabled),
+                ),
+              ),
+            ),
+          );
+          expect(
+            find.byType(fn.value),
+            enabled ? findsOneWidget : findsNothing,
+          );
+          if (!enabled) {
+            await tester.pump(const Duration(seconds: 2));
+            expect(tester.binding.transientCallbackCount, 0);
+          }
+          expect(tester.takeException(), isNull);
+        }
+      });
+    }
   });
 
   group('MfmText アニメーション共通テスト', () {
@@ -1222,6 +1360,21 @@ $[spin 10] $[jump 11] $[bounce 12] $[shake 13]
       expect(hasBounceTransform, isTrue);
     });
   });
+}
+
+Iterable<TextStyle> _textStyles(
+  InlineSpan span, [
+  TextStyle inherited = const TextStyle(),
+]) sync* {
+  if (span is TextSpan) {
+    final style = inherited.merge(span.style);
+    if (span.text?.isNotEmpty ?? false) {
+      yield style;
+    }
+    for (final child in span.children ?? <InlineSpan>[]) {
+      yield* _textStyles(child, style);
+    }
+  }
 }
 
 /// InlineSpanにテキストが含まれているかを再帰的に検索するヘルパー関数

--- a/test/widget/mfm_fn_test.dart
+++ b/test/widget/mfm_fn_test.dart
@@ -1825,6 +1825,49 @@ void main() {
     });
   });
 
+  group('MfmText advanced無効時のサイズ・scale', () {
+    for (final fn in ['x2', 'x3', 'x4', 'scale.x=3,y=2']) {
+      testWidgets('$fnはfontSizeとTransformを変更しない', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MfmText(
+                text: 'before\$[$fn **body**]after',
+                config: const MfmRenderConfig(
+                  baseTextStyle: TextStyle(fontSize: 14),
+                  enableAdvancedMfm: false,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final richText = tester.widget<RichText>(find.byType(RichText));
+        expect(richText.text.toPlainText(), 'beforebodyafter');
+        expect(richText.text.style?.fontSize, 14);
+        richText.text.visitChildren((span) {
+          expect(span.style?.fontSize, anyOf(isNull, 14));
+          return true;
+        });
+        expect(_collectWidgetSpans(richText.text), isEmpty);
+        expect(
+          find.descendant(
+            of: find.byType(MfmText),
+            matching: find.byType(Transform),
+          ),
+          findsNothing,
+        );
+        expect(
+          _findSpanWithStyle(
+            richText.text as TextSpan,
+            (style) => style?.fontWeight == FontWeight.bold,
+          )?.toPlainText(),
+          'body',
+        );
+      });
+    }
+  });
+
   group('MfmText 未知のfn関数', () {
     testWidgets('未知のfn関数はリテラルで表示する', (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## 概要

`MfmRenderConfig.enableAdvancedMfm` が `position` にしか効いておらず、無効にしても拡大もアニメーションも止まらない問題を修正します。

本家では `useAnim = prefer.s.advancedMfm && prefer.s.animatedMfm` が全アニメーション fn の共通ゲートになっており、`advancedMfm` を切ると x2/x3/x4 の CSS クラスが付かず（文字サイズ不変）、`scale` は `style=''` で変形なし、`position` はリテラル表示になります。

## 変更内容

- `MfmRenderConfig.useAnimation => enableAdvancedMfm && enableAnimation` を追加し、spin / jump / bounce / shake / twitch / jelly / tada / rainbow / sparkle の 9 fn の有効判定と各 widget の `enabled` をこれに統一
- `_buildSize`: advanced 無効時はフォントサイズを変更せず子をそのまま描画。本家 `genEl(children, scale * N)` と同じく公称倍率 2/3/4 の伝播は継続（絵文字の `useOriginalSize` 判定に効く）
- `_buildScale`: advanced 無効時は `Transform` も倍率伝播もしない（本家は `scale = scale * max(x, y)` の行に到達しない）
- 無効時の静的表示を本家に合わせて整理: tada は 150% の `TextSpan` のみ（`MfmTadaWidget` を生成しない）、rainbow は静的グラデーションを `MfmStaticRainbowWidget` として分離（色・停止位置は従来どおり `_mfm_rainbow_fallback_` と同じ）、sparkle は `MfmSparkleWidget` を生成せず素の子
- `enableAdvancedMfm` / `enableAnimation` の doc コメントを実際の効果範囲に更新（「将来用」を削除）。既定値は両方 `true` のまま
- 回帰テスト 65 件を追加（両フラグの組合せ × 9 fn、x2/x3/x4 の倍率伝播継続と scale fn の伝播停止、切替による停止・再開）。既存の tada テストを新挙動に更新
- README 英日の「Advanced MFM control」節・config 表・絵文字文脈・scale・入れ子サイズの説明、CHANGELOG を更新

## 補足

- 静的 scale / tada 等は `TextSpan` で返すため、本家の空 `inline-block` span が作る行レイアウト境界までは再現しません（Transform もレイアウト作用もないため描画意味を持つ WidgetSpan を追加しない判断）。
- 本家の `animatedMfm` 既定値は `!prefersReducedMotion` ですが、OS の reduced motion 連動は本 PR の対象外です（既定値を変えない）。
- 有効時の rainbow の描画方式（hue-rotate 化、#40）は別 PR で対応します。

## 検証

- `dart format`
- `flutter analyze --fatal-infos`（No issues found）
- `flutter test`（679件成功）
- `git diff --check`

Closes #37
