### PR TITLE
feat: exampleのカタログに未掲載の構文・fnと新機能の確認サンプルを追加

### DIFF
--- a/example/lib/features/catalog/data/mfm_examples.dart
+++ b/example/lib/features/catalog/data/mfm_examples.dart
@@ -309,7 +309,9 @@ class MfmExamples {
           syntax: ':ai_smile_misskeyio: :pudding_cat: :not_in_map:',
           mfm: ':ai_smile_misskeyio: :pudding_cat: :not_in_map:',
           description:
-              '設定パネルの「リモート投稿として扱う」「emojiUrls を渡す」「絵文字の文脈を表示」で経路が変わります。ローカルresolver、直接URL、mapにキー無しならショートコード、mapなしならリモートエンドポイント取得となり、失敗時はショートコード表示です',
+              '設定パネルの「リモート投稿として扱う」「emojiUrls を渡す」「絵文字の文脈を表示」で経路が変わります。'
+              'ローカルresolver、直接URL、mapにキー無しならショートコード、'
+              'mapなしならリモートエンドポイント取得となり、失敗時はショートコード表示です',
         ),
         MfmExample(
           name: 'Custom Emoji (x2)',

--- a/example/lib/features/catalog/data/mfm_examples.dart
+++ b/example/lib/features/catalog/data/mfm_examples.dart
@@ -51,6 +51,11 @@ class MfmExamples {
           mfm: '*斜体テキスト*',
         ),
         MfmExample(
+          name: 'Italic (HTML)',
+          syntax: '<i>text</i>',
+          mfm: '<i>HTML形式の斜体</i>',
+        ),
+        MfmExample(
           name: 'Strike',
           syntax: '~~text~~',
           mfm: '~~打ち消し線~~',
@@ -59,6 +64,18 @@ class MfmExamples {
           name: 'Small',
           syntax: '<small>text</small>',
           mfm: '<small>小さいテキスト</small>',
+        ),
+        MfmExample(
+          name: 'Small (ネスト)',
+          syntax: '<small><small>text</small></small>',
+          mfm: '<small>外側 <small>内側はさらに小さく薄く表示</small></small>',
+          description: 'ネストごとに文字サイズは0.8倍、不透明度は0.7倍になります',
+        ),
+        MfmExample(
+          name: 'Plain',
+          syntax: r'<plain>**text**$[x2 text]</plain>',
+          mfm: r'<plain>**そのまま**$[x2 表示]</plain>',
+          description: '内側の構文は解釈されず、そのまま表示されます',
         ),
         MfmExample(
           name: 'Center',
@@ -76,6 +93,26 @@ class MfmExamples {
           name: 'Quote',
           syntax: '> text',
           mfm: '> 引用テキスト',
+        ),
+        MfmExample(
+          name: 'Quote (複数行)',
+          syntax: '> line 1\n> line 2',
+          mfm: '> 1行目\n> 2行目',
+        ),
+        MfmExample(
+          name: 'Quote (ネスト)',
+          syntax: '>> text',
+          mfm: '>> 二重の引用',
+        ),
+        MfmExample(
+          name: 'Quote (fn内)',
+          syntax: r'> $[x2 text]',
+          mfm: r'> $[x2 大きい引用]',
+        ),
+        MfmExample(
+          name: 'Quote (連続)',
+          syntax: '> first\n\n> second',
+          mfm: '> 1つ目の引用\n\n> 2つ目の引用',
         ),
         MfmExample(
           name: 'Code Block',
@@ -158,6 +195,24 @@ class MfmExamples {
           syntax: '`code`',
           mfm: 'インライン`コード`の例',
         ),
+        MfmExample(
+          name: 'Math Block',
+          syntax: r'\[ x^2 + y^2 = z^2 \]',
+          mfm: r'\[ x^2 + y^2 = z^2 \]',
+          description: '等幅の式文字列として表示され、LaTeX組版は行いません',
+        ),
+        MfmExample(
+          name: 'Math Inline',
+          syntax: r'\( E = mc^2 \)',
+          mfm: r'質量とエネルギーの関係は \( E = mc^2 \) です。',
+          description: '等幅の式文字列として表示され、LaTeX組版は行いません',
+        ),
+        MfmExample(
+          name: 'Search',
+          syntax: 'keyword 検索 / keyword [検索] / keyword Search',
+          mfm: 'Misskey 検索\nMisskey [検索]\nMisskey Search',
+          description: 'ボタンをタップすると onSearchTap が呼ばれます',
+        ),
       ],
     ),
 
@@ -171,14 +226,48 @@ class MfmExamples {
           mfm: 'https://misskey.io',
         ),
         MfmExample(
+          name: 'URL (分解表示)',
+          syntax: 'https://example.org/notes/abcdef?from=timeline#reply',
+          mfm: 'https://example.org/notes/abcdef?from=timeline#reply',
+          description: 'スキーム・クエリは減光、ホストは太字、ハッシュは斜体で外部リンクアイコンを表示します',
+        ),
+        MfmExample(
+          name: 'URL (punycode)',
+          syntax: 'https://xn--wgv71a119e.jp/%E3%83%86%E3%82%B9%E3%83%88',
+          mfm: 'https://xn--wgv71a119e.jp/%E3%83%86%E3%82%B9%E3%83%88',
+          description: 'ホストは日本語.jpに復号し、パスもデコードして表示します',
+        ),
+        MfmExample(
+          name: 'URL (自ホスト)',
+          syntax: 'https://misskey.io/@syuilo',
+          mfm: 'https://misskey.io/@syuilo',
+          description: 'localHost=misskey.ioではスキームとホストを省略して表示します',
+        ),
+        MfmExample(
           name: 'Link',
           syntax: '[label](url)',
           mfm: '[Misskey公式](https://misskey.io)',
         ),
         MfmExample(
+          name: 'Link (ラベル付き)',
+          syntax: '[label](https://example.org/@user)',
+          mfm: '[ユーザープロフィール](https://example.org/@user)',
+        ),
+        MfmExample(
+          name: 'Silent Link',
+          syntax: '?[label](url)',
+          mfm: '?[サイレントリンク](https://example.org)',
+          description: 'レンダラーでは通常リンクと同じ表示になります',
+        ),
+        MfmExample(
           name: 'Mention',
           syntax: '@user',
           mfm: '@example_user',
+        ),
+        MfmExample(
+          name: 'Mention (リモート)',
+          syntax: '@user@host',
+          mfm: '@user@misskey.example',
         ),
         MfmExample(
           name: 'Hashtag',
@@ -209,6 +298,25 @@ class MfmExamples {
           mfm: 'こんにちは :pudding_cat: よろしく :icon_syuilo:',
           description: 'Misskey.ioの実在絵文字を混在表示',
         ),
+        MfmExample(
+          name: 'Custom Emoji (存在しない)',
+          syntax: ':not_exist_emoji:',
+          mfm: ':not_exist_emoji:',
+          description: '存在しない絵文字はショートコードのまま表示されます',
+        ),
+        MfmExample(
+          name: 'Custom Emoji (リモート)',
+          syntax: ':ai_smile_misskeyio: :pudding_cat: :not_in_map:',
+          mfm: ':ai_smile_misskeyio: :pudding_cat: :not_in_map:',
+          description:
+              '設定パネルの「リモート投稿として扱う」「emojiUrls を渡す」「絵文字の文脈を表示」で経路が変わります。ローカルresolver、直接URL、mapにキー無しならショートコード、mapなしならリモートエンドポイント取得となり、失敗時はショートコード表示です',
+        ),
+        MfmExample(
+          name: 'Custom Emoji (x2)',
+          syntax: r'$[x2 :ai_smile_misskeyio:]',
+          mfm: r'$[x2 :ai_smile_misskeyio:]',
+          description: '絵文字も x2 の中では拡大します',
+        ),
       ],
     ),
 
@@ -220,6 +328,7 @@ class MfmExamples {
           name: 'x2',
           syntax: r'$[x2 text]',
           mfm: r'$[x2 2倍サイズ]',
+          description: 'Advanced MFM をオフにすると拡大しません',
         ),
         MfmExample(
           name: 'x3',
@@ -230,6 +339,12 @@ class MfmExamples {
           name: 'x4',
           syntax: r'$[x4 text]',
           mfm: r'$[x4 4倍サイズ]',
+        ),
+        MfmExample(
+          name: 'x2 (ネスト)',
+          syntax: r'$[x2 $[x2 text]]',
+          mfm: r'$[x2 $[x2 ネスト]]',
+          description: '実効サイズは3倍になり、3段目以降は拡大しません',
         ),
       ],
     ),
@@ -249,9 +364,19 @@ class MfmExamples {
           mfm: r'$[flip.v 上下反転]',
         ),
         MfmExample(
+          name: 'Flip (both)',
+          syntax: r'$[flip.h,v text]',
+          mfm: r'$[flip.h,v 両方反転]',
+        ),
+        MfmExample(
           name: 'Rotate',
           syntax: r'$[rotate.deg=45 text]',
           mfm: r'$[rotate.deg=45 45度回転]',
+        ),
+        MfmExample(
+          name: 'Rotate (負角度)',
+          syntax: r'$[rotate.deg=-30 text]',
+          mfm: r'$[rotate.deg=-30 左に30度回転]',
         ),
         MfmExample(
           name: 'Scale',
@@ -259,9 +384,20 @@ class MfmExamples {
           mfm: r'$[scale.x=2,y=0.5 拡大縮小]',
         ),
         MfmExample(
+          name: 'Scale (上限)',
+          syntax: r'$[scale.x=10,y=10 text]',
+          mfm: r'$[scale.x=10,y=10 上限]',
+          description: '各軸の倍率は ±5 に制限されます',
+        ),
+        MfmExample(
           name: 'Position',
           syntax: r'$[position.x=1,y=1 text]',
           mfm: r'$[position.x=1,y=1 位置移動]',
+        ),
+        MfmExample(
+          name: 'Position (負値)',
+          syntax: r'$[position.x=-1,y=-0.5 text]',
+          mfm: r'$[position.x=-1,y=-0.5 左上へ移動]',
         ),
       ],
     ),
@@ -276,9 +412,31 @@ class MfmExamples {
           mfm: r'$[fg.color=ff0000 赤い文字]',
         ),
         MfmExample(
+          name: 'Foreground Color (3桁)',
+          syntax: r'$[fg.color=f00 text]',
+          mfm: r'$[fg.color=f00 3桁]',
+        ),
+        MfmExample(
+          name: 'Foreground Color (RGBA)',
+          syntax: r'$[fg.color=0f08 text]',
+          mfm: r'$[fg.color=0f08 4桁RGBA]',
+          description: '4桁のRGBA形式も指定できます',
+        ),
+        MfmExample(
+          name: 'Foreground Color (不正値)',
+          syntax: r'$[fg.color=zzz text]',
+          mfm: r'$[fg.color=zzz 不正値→赤]',
+          description: '3〜6桁の16進数以外は赤で表示されます',
+        ),
+        MfmExample(
           name: 'Background Color',
           syntax: r'$[bg.color=00ff00 text]',
           mfm: r'$[bg.color=00ff00 緑の背景]',
+        ),
+        MfmExample(
+          name: 'Background Color (3桁)',
+          syntax: r'$[bg.color=ff0 text]',
+          mfm: r'$[bg.color=ff0 背景]',
         ),
         MfmExample(
           name: 'Border',
@@ -286,9 +444,41 @@ class MfmExamples {
           mfm: r'$[border.color=0000ff 青い枠線]',
         ),
         MfmExample(
+          name: 'Border (オプション)',
+          syntax: r'$[border.width=3,radius=8 text]',
+          mfm: r'$[border.width=3,radius=8 枠線オプション]',
+        ),
+        MfmExample(
+          name: 'Border (破線指定)',
+          syntax: r'$[border.style=dashed text]',
+          mfm: r'$[border.style=dashed 破線指定]',
+          description: '破線・点線の指定は実線にフォールバックします',
+        ),
+        MfmExample(
+          name: 'Border (既定色)',
+          syntax: r'$[border text]',
+          mfm: r'$[border 既定色]',
+          description: '色を省略すると accent 色の枠線になります',
+        ),
+        MfmExample(
           name: 'Font',
           syntax: r'$[font.monospace text]',
           mfm: r'$[font.monospace 等幅フォント]',
+        ),
+        MfmExample(
+          name: 'Font (serif)',
+          syntax: r'$[font.serif text]',
+          mfm: r'$[font.serif セリフ体]',
+        ),
+        MfmExample(
+          name: 'Font (cursive)',
+          syntax: r'$[font.cursive text]',
+          mfm: r'$[font.cursive 筆記体]',
+        ),
+        MfmExample(
+          name: 'Font (fantasy)',
+          syntax: r'$[font.fantasy text]',
+          mfm: r'$[font.fantasy ファンタジー]',
         ),
       ],
     ),
@@ -306,6 +496,22 @@ class MfmExamples {
           name: 'Ruby',
           syntax: r'$[ruby 漢字 振り仮名]',
           mfm: r'$[ruby 漢字 かんじ]',
+        ),
+        MfmExample(
+          name: 'Unixtime (過去)',
+          syntax: r'$[unixtime 1700000000]',
+          mfm: r'$[unixtime 1700000000]',
+        ),
+        MfmExample(
+          name: 'Unixtime (未来)',
+          syntax: r'$[unixtime 2000000000]',
+          mfm: r'$[unixtime 2000000000]',
+        ),
+        MfmExample(
+          name: 'Clickable',
+          syntax: r'$[clickable.ev=hello text]',
+          mfm: r'$[clickable.ev=hello タップで onClickableEvent]',
+          description: 'タップすると onClickableEvent が呼ばれます',
         ),
       ],
     ),
@@ -349,6 +555,18 @@ class MfmExamples {
           syntax: r'$[spin.speed=0.5s text]',
           mfm: r'$[spin.speed=0.5s 高速回転]',
           description: 'アニメーション速度を指定',
+        ),
+        MfmExample(
+          name: 'Spin (速度0)',
+          syntax: r'$[spin.speed=0s text]',
+          mfm: r'$[spin.speed=0s 通常表示]',
+          description: 'speed が 0 のときは通常表示になります',
+        ),
+        MfmExample(
+          name: 'Spin (負の遅延)',
+          syntax: r'$[spin.delay=-0.5s text]',
+          mfm: r'$[spin.delay=-0.5s 位相を進めて開始]',
+          description: '0.5秒進んだ位相から開始します',
         ),
         MfmExample(
           name: 'Jump',
@@ -395,6 +613,12 @@ class MfmExamples {
           mfm: r'$[twitch.speed=0.3s 激しく動く]',
         ),
         MfmExample(
+          name: 'Twitch / Shake (easing)',
+          syntax: r'$[twitch text] $[shake text]',
+          mfm: r'$[twitch twitch] $[shake shake]',
+          description: 'どちらも隣接するキーフレーム間ごとに ease を適用します',
+        ),
+        MfmExample(
           name: 'Jelly',
           syntax: r'$[jelly text]',
           mfm: r'$[jelly ぷるぷる]',
@@ -409,7 +633,7 @@ class MfmExamples {
           name: 'Tada',
           syntax: r'$[tada text]',
           mfm: r'$[tada じゃーん!]',
-          description: '150%サイズで揺れるアニメーション',
+          description: '150%サイズで揺れ、Advanced MFM をオフにしても150%の拡大は残ります',
         ),
         MfmExample(
           name: 'Tada (速度調整)',
@@ -426,6 +650,18 @@ class MfmExamples {
           name: 'Rainbow (速度調整)',
           syntax: r'$[rainbow.speed=0.5s text]',
           mfm: r'$[rainbow.speed=0.5s 速く虹色]',
+        ),
+        MfmExample(
+          name: 'Rainbow (無彩色)',
+          syntax: r'$[rainbow $[fg.color=888 text]]',
+          mfm: r'$[rainbow $[fg.color=888 灰色の本文]]',
+          description: 'hue-rotateのため無彩色は色相が循環せず、明度だけがわずかに変化します',
+        ),
+        MfmExample(
+          name: 'Rainbow (有彩色)',
+          syntax: r'$[rainbow $[fg.color=f00 text]]',
+          mfm: r'$[rainbow $[fg.color=f00 赤い文字]]',
+          description: 'アニメーション無効時は静的な虹色で表示します',
         ),
         MfmExample(
           name: 'Sparkle',
@@ -475,6 +711,39 @@ class MfmExamples {
 $[x2 大きな文字]も$[fg.color=ff0000 色付き文字]も！
 
 @user さんへの #MFM のデモです。''',
+        ),
+        MfmExample(
+          name: 'Nyaize',
+          syntax: '通常の文章',
+          mfm: 'なんとなく、明日はいい天気になりそうだな。Everyone, good morning!',
+          description: '設定の nyaize モードと「投稿者は猫」で変化します',
+        ),
+        MfmExample(
+          name: 'Plain / Nowrap',
+          syntax: '複数行の長文',
+          mfm:
+              'これは複数行で表示するための少し長いテキストです。構文の **太字** も含みます。\n'
+              '設定の plain では改行が空白になり、nowrap では1行に省略表示されます。',
+          description: '設定の plain で改行が空白に、nowrap で1行に省略表示されます',
+        ),
+        MfmExample(
+          name: '本家ノート風の複合例',
+          syntax: 'メンション・タグ・URL・引用・コード・絵文字・fnを含む投稿',
+          mfm: r'''@alice こんにちは、#MFM の確認です。
+https://example.org/notes/abcdef?from=timeline#reply
+
+> $[fg.color=0af 引用内の色付きテキスト]
+> 2行目の引用です。
+
+`inline code` と :ai_smile_misskeyio: を並べます。
+
+```dart
+final message = 'hello';
+```
+
+$[x2 $[rainbow 完了！]]
+?[関連リンク](https://example.org/docs)''',
+          description: '本家のノートに近い複数要素の組み合わせです',
         ),
       ],
     ),

--- a/example/lib/features/catalog/data/mfm_examples.dart
+++ b/example/lib/features/catalog/data/mfm_examples.dart
@@ -733,18 +733,13 @@ $[x2 大きな文字]も$[fg.color=ff0000 色付き文字]も！
           syntax: 'メンション・タグ・URL・引用・コード・絵文字・fnを含む投稿',
           mfm: r'''@alice こんにちは、#MFM の確認です。
 https://example.org/notes/abcdef?from=timeline#reply
-
 > $[fg.color=0af 引用内の色付きテキスト]
 > 2行目の引用です。
-
 `inline code` と :ai_smile_misskeyio: を並べます。
-
 ```dart
 final message = 'hello';
 ```
-
-$[x2 $[rainbow 完了！]]
-?[関連リンク](https://example.org/docs)''',
+$[x2 $[rainbow 完了！]] ?[関連リンク](https://example.org/docs)''',
           description: '本家のノートに近い複数要素の組み合わせです',
         ),
       ],

--- a/example/test/catalog_examples_test.dart
+++ b/example/test/catalog_examples_test.dart
@@ -1,0 +1,163 @@
+import 'package:example/features/catalog/data/mfm_examples.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+void main() {
+  final examples = MfmExamples.categories
+      .expand((category) => category.examples)
+      .toList(growable: false);
+
+  test('カタログのサンプル名と表示用構文は有効', () {
+    final names = examples.map((example) => example.name).toList();
+
+    expect(names.toSet(), hasLength(names.length));
+    for (final example in examples) {
+      expect(example.syntax, isNotEmpty, reason: example.name);
+      expect(example.mfm, isNotEmpty, reason: example.name);
+    }
+  });
+
+  testWidgets('全サンプルを構文どおりに描画できる', (tester) async {
+    for (final example in examples) {
+      await _pumpMfm(tester, example.mfm);
+
+      final plainText = _richTextPlainText(tester);
+      if (example.name == 'Plain') {
+        expect(plainText, contains('**そのまま**'));
+        expect(plainText, contains(r'$[x2 表示]'));
+      } else {
+        for (final literalSyntax in const [
+          r'$[',
+          '**',
+          '~~',
+          '<center>',
+          '<small>',
+          '<i>',
+        ]) {
+          expect(
+            plainText,
+            isNot(contains(literalSyntax)),
+            reason: '${example.name} に未解釈の構文があります',
+          );
+        }
+      }
+    }
+  });
+
+  testWidgets('Bold は太字のTextSpanとして描画される', (tester) async {
+    await _pumpExample(tester, 'Bold');
+
+    expect(
+      _textSpans(tester).any(
+        (span) => span.style?.fontWeight == FontWeight.bold,
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('Italic は斜体のTextSpanとして描画される', (tester) async {
+    await _pumpExample(tester, 'Italic (HTML)');
+
+    expect(
+      _textSpans(tester).any(
+        (span) => span.style?.fontStyle == FontStyle.italic,
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('不正なfg色は赤として描画される', (tester) async {
+    await _pumpExample(tester, 'Foreground Color (不正値)');
+
+    expect(
+      _textSpans(tester).any(
+        (span) => span.style?.color == const Color(0xFFFF0000),
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('x2 は元の2倍のフォントサイズで描画される', (tester) async {
+    await _pumpExample(tester, 'x2');
+
+    expect(
+      _textSpans(tester).any((span) => span.style?.fontSize == 28),
+      isTrue,
+    );
+  });
+
+  testWidgets('Math Block は等幅フォントで描画される', (tester) async {
+    await _pumpExample(tester, 'Math Block');
+
+    expect(
+      _textSpans(tester).any((span) => span.style?.fontFamily == 'monospace'),
+      isTrue,
+    );
+  });
+
+  testWidgets('punycode URL は復号したホスト名を表示する', (tester) async {
+    await _pumpExample(tester, 'URL (punycode)');
+
+    expect(_richTextPlainText(tester), contains('日本語.jp'));
+  });
+
+  testWidgets('Search は検索ボタンを描画する', (tester) async {
+    await _pumpExample(tester, 'Search');
+
+    expect(find.text('Search'), findsWidgets);
+  });
+}
+
+Future<void> _pumpExample(WidgetTester tester, String name) {
+  final example = MfmExamples.categories
+      .expand((category) => category.examples)
+      .singleWhere((example) => example.name == name);
+  return _pumpMfm(tester, example.mfm);
+}
+
+Future<void> _pumpMfm(WidgetTester tester, String mfm) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          child: MfmText(text: mfm),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+String _richTextPlainText(WidgetTester tester) {
+  return tester
+      .widgetList<RichText>(find.byType(RichText))
+      .map((richText) => richText.text.toPlainText())
+      .join();
+}
+
+List<TextSpan> _textSpans(WidgetTester tester) {
+  final spans = <TextSpan>[];
+  for (final richText in tester.widgetList<RichText>(find.byType(RichText))) {
+    richText.text.visitChildren((child) {
+      if (child is TextSpan) {
+        spans.add(child);
+      }
+      return true;
+    });
+    _collectStyledTextSpans(richText.text, spans);
+  }
+  return spans;
+}
+
+void _collectStyledTextSpans(InlineSpan span, List<TextSpan> textSpans) {
+  if (span is! TextSpan || span.children == null) {
+    return;
+  }
+
+  textSpans.add(span);
+  for (final child in span.children!) {
+    _collectStyledTextSpans(child, textSpans);
+  }
+}


### PR DESCRIPTION
## 概要
example のカタログに、README の対応表にあるノード・fn のうち未掲載だったものと、直近で追加された挙動（URL の分解表示、punycode 復号、自ホスト URL の短縮、リモート絵文字の解決経路、nyaize、plain / nowrap、Advanced MFM 無効時の挙動、twitch / shake の区間 easing、rainbow の無彩色）を確認できるサンプルを追加します。

## 変更内容
- テキスト整形: `<i>`、`<plain>`、Small のネスト
- ブロック要素: 複数行・ネスト・連続の引用、Math Block / Inline、Search（3 形式）
- リンク・参照: URL 分解表示（外部ホスト）、punycode URL、自ホスト URL、ラベル付きリンク、サイレントリンク、リモートメンション
- 絵文字: 存在しない絵文字、リモート絵文字の経路確認用、x2 内の絵文字
- fn: x2 のネスト、flip.h,v、負角度 rotate、scale の上限、負値 position、fg の 3 桁 / 4 桁 RGBA / 不正値、bg 3 桁、border のオプション / 破線指定 / 既定色、font.serif / cursive / fantasy、unixtime（過去・未来）、clickable
- アニメーション: speed=0、負の delay、twitch / shake の並置、rainbow の無彩色 / 有彩色
- 設定パネルで確認する例: nyaize、plain / nowrap、本家ノート風の複合例
- 各 description を実装の挙動に合わせて記載（破線は実線にフォールバック、fg は 3〜6 桁のみ、tada は Advanced MFM オフでも 150% 維持、絵文字は x2 で拡大、など）
- `example/test/catalog_examples_test.dart` を追加: サンプル名の一意性、全サンプルの描画、構文がリテラルに落ちていないこと、代表例の意味的な検証（太字・斜体・不正 fg → 赤・x2 → 2 倍・Math → 等幅・punycode → 日本語.jp・Search → ボタン）

## 補足
リモート絵文字・nyaize・plain / nowrap のサンプルは、設定パネル（別 PR）で切り替えたときに見た目が変わることを前提に説明を書いています。

## 検証
- `cd example && flutter test`: 10 件成功（アニメーションを含むため `pumpAndSettle` は使用せず `pump` のみ）
- `cd example && flutter analyze --fatal-infos` / ルート `flutter analyze --fatal-infos`: No issues found
- `dart format --set-exit-if-changed .` / `git diff --check`: 成功

## Stack
- Depends on #91
- Base branch: `feature/example-test-baseline`
