### PR TITLE
feat: exampleに設定パネルとコールバック表示を追加し描画設定を実行時に切り替えられるようにする

### DIFF
--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -2,38 +2,83 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
 
+import '../core/callbacks/example_callbacks.dart';
+import '../core/settings/example_settings.dart';
 import 'home_page.dart';
 import 'theme/app_theme.dart';
 
-class MfmExampleApp extends StatelessWidget {
+class MfmExampleApp extends StatefulWidget {
   const MfmExampleApp({super.key, this.config});
 
   final MfmRenderConfig? config;
 
   @override
-  Widget build(BuildContext context) {
-    final app = MaterialApp(
-      title: 'MFM Renderer Example',
-      theme: AppTheme.light,
-      darkTheme: AppTheme.dark,
-      home: const HomePage(),
-      debugShowCheckedModeBanner: false,
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('ja', 'JP'),
-      ],
-    );
+  State<MfmExampleApp> createState() => _MfmExampleAppState();
+}
 
-    if (config == null) {
-      return app;
+class _MfmExampleAppState extends State<MfmExampleApp> {
+  final _settings = ExampleSettings();
+  final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+  late final ExampleCallbacks _callbacks;
+  late MfmRenderConfig _baseConfig;
+  late MfmRenderConfig _renderConfig;
+
+  @override
+  void initState() {
+    super.initState();
+    _callbacks = ExampleCallbacks(_scaffoldMessengerKey);
+    _baseConfig = widget.config ?? const MfmRenderConfig();
+    _renderConfig = buildRenderConfig(_settings, _baseConfig, _callbacks);
+    _settings.addListener(_updateRenderConfig);
+  }
+
+  @override
+  void didUpdateWidget(covariant MfmExampleApp oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.config != oldWidget.config) {
+      _baseConfig = widget.config ?? const MfmRenderConfig();
+      _renderConfig = buildRenderConfig(_settings, _baseConfig, _callbacks);
     }
-    return MfmConfig(
-      config: config!,
-      child: app,
+  }
+
+  @override
+  void dispose() {
+    _settings
+      ..removeListener(_updateRenderConfig)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ExampleSettingsScope(
+      settings: _settings,
+      child: MfmConfig(
+        config: _renderConfig,
+        child: MaterialApp(
+          title: 'MFM Renderer Example',
+          theme: AppTheme.light,
+          darkTheme: AppTheme.dark,
+          themeMode: _settings.themeMode,
+          scaffoldMessengerKey: _scaffoldMessengerKey,
+          home: const HomePage(),
+          debugShowCheckedModeBanner: false,
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [
+            Locale('ja', 'JP'),
+          ],
+        ),
+      ),
     );
+  }
+
+  void _updateRenderConfig() {
+    setState(() {
+      _renderConfig = buildRenderConfig(_settings, _baseConfig, _callbacks);
+    });
   }
 }

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -61,7 +61,9 @@ class _MfmExampleAppState extends State<MfmExampleApp> {
           darkTheme: AppTheme.dark,
           themeMode: _settings.themeMode,
           scaffoldMessengerKey: _scaffoldMessengerKey,
-          home: const HomePage(),
+          home: HomePage(
+            emojiInitialized: widget.config is MfmEmojiConfigHandle,
+          ),
           debugShowCheckedModeBanner: false,
           localizationsDelegates: const [
             GlobalMaterialLocalizations.delegate,

--- a/example/lib/app/home_page.dart
+++ b/example/lib/app/home_page.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 
 import '../features/catalog/presentation/catalog_tab.dart';
 import '../features/playground/presentation/playground_tab.dart';
+import 'widgets/settings_drawer.dart';
 
-/// ホーム画面（BottomNavigationBar付き）
+/// ホーム画面
 class HomePage extends StatefulWidget {
-  const HomePage({super.key});
+  const HomePage({super.key, required this.emojiInitialized});
+
+  final bool emojiInitialized;
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -21,34 +24,78 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('MFM Renderer'),
-      ),
-      body: IndexedStack(
-        index: _selectedIndex,
-        children: _pages,
-      ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _selectedIndex,
-        onDestinationSelected: (index) {
-          setState(() {
-            _selectedIndex = index;
-          });
-        },
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.list_alt_outlined),
-            selectedIcon: Icon(Icons.list_alt),
-            label: 'カタログ',
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useNavigationRail = constraints.maxWidth >= 600;
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('MFM Renderer'),
+            actions: [
+              Builder(
+                builder: (context) => IconButton(
+                  key: const Key('openSettingsDrawerButton'),
+                  tooltip: '表示設定',
+                  icon: const Icon(Icons.tune),
+                  onPressed: () => Scaffold.of(context).openEndDrawer(),
+                ),
+              ),
+            ],
           ),
-          NavigationDestination(
-            icon: Icon(Icons.edit_note_outlined),
-            selectedIcon: Icon(Icons.edit_note),
-            label: 'プレイグラウンド',
-          ),
-        ],
-      ),
+          endDrawer: SettingsDrawer(emojiInitialized: widget.emojiInitialized),
+          body: useNavigationRail
+              ? Row(
+                  children: [
+                    NavigationRail(
+                      selectedIndex: _selectedIndex,
+                      onDestinationSelected: _selectDestination,
+                      labelType: NavigationRailLabelType.all,
+                      destinations: const [
+                        NavigationRailDestination(
+                          icon: Icon(Icons.list_alt_outlined),
+                          selectedIcon: Icon(Icons.list_alt),
+                          label: Text('カタログ'),
+                        ),
+                        NavigationRailDestination(
+                          icon: Icon(Icons.edit_note_outlined),
+                          selectedIcon: Icon(Icons.edit_note),
+                          label: Text('プレイグラウンド'),
+                        ),
+                      ],
+                    ),
+                    const VerticalDivider(width: 1),
+                    Expanded(child: _pageStack),
+                  ],
+                )
+              : _pageStack,
+          bottomNavigationBar: useNavigationRail
+              ? null
+              : NavigationBar(
+                  selectedIndex: _selectedIndex,
+                  onDestinationSelected: _selectDestination,
+                  destinations: const [
+                    NavigationDestination(
+                      icon: Icon(Icons.list_alt_outlined),
+                      selectedIcon: Icon(Icons.list_alt),
+                      label: 'カタログ',
+                    ),
+                    NavigationDestination(
+                      icon: Icon(Icons.edit_note_outlined),
+                      selectedIcon: Icon(Icons.edit_note),
+                      label: 'プレイグラウンド',
+                    ),
+                  ],
+                ),
+        );
+      },
     );
+  }
+
+  Widget get _pageStack =>
+      IndexedStack(index: _selectedIndex, children: _pages);
+
+  void _selectDestination(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
   }
 }

--- a/example/lib/app/widgets/settings_drawer.dart
+++ b/example/lib/app/widgets/settings_drawer.dart
@@ -1,0 +1,303 @@
+import 'package:flutter/material.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+import '../../core/settings/example_settings.dart';
+
+class SettingsDrawer extends StatelessWidget {
+  const SettingsDrawer({super.key, required this.emojiInitialized});
+
+  final bool emojiInitialized;
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = ExampleSettingsScope.of(context);
+
+    return Drawer(
+      child: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.only(bottom: 24),
+          children: [
+            ListTile(
+              title: const Text('表示設定'),
+              subtitle: Text(
+                emojiInitialized
+                    ? '絵文字: misskey.io と同期済み'
+                    : '絵文字: 初期化に失敗（ネットワークが必要。カスタム絵文字はショートコード表示）',
+              ),
+              trailing: IconButton(
+                tooltip: 'リセット',
+                icon: const Icon(Icons.restart_alt),
+                onPressed: settings.reset,
+              ),
+            ),
+            const Divider(),
+            _Section(
+              title: '表示',
+              child: Column(
+                children: [
+                  _SegmentedSetting<ThemeMode>(
+                    title: 'テーマ',
+                    subtitle: 'アプリと MFM の明暗を切り替えます',
+                    selected: {settings.themeMode},
+                    onSelectionChanged: (selection) {
+                      settings.themeMode = selection.single;
+                    },
+                    segments: const [
+                      ButtonSegment(
+                        value: ThemeMode.system,
+                        label: Text('システム'),
+                      ),
+                      ButtonSegment(
+                        value: ThemeMode.light,
+                        label: Text('ライト'),
+                      ),
+                      ButtonSegment(
+                        value: ThemeMode.dark,
+                        label: Text('ダーク'),
+                      ),
+                    ],
+                  ),
+                  SwitchListTile(
+                    title: const Text('カスタム配色'),
+                    subtitle: const Text('リンクやメンションなどを紫系の配色に上書きします'),
+                    value: settings.useCustomColorScheme,
+                    onChanged: (value) {
+                      settings.useCustomColorScheme = value;
+                    },
+                  ),
+                ],
+              ),
+            ),
+            _Section(
+              title: 'MFM',
+              child: Column(
+                children: [
+                  SwitchListTile(
+                    key: const Key('enableAdvancedMfmSwitch'),
+                    title: const Text('Advanced MFM'),
+                    subtitle: const Text(
+                      'オフにすると x2〜x4 の拡大、scale、アニメーションが無効になります'
+                      '（tada の 150% 拡大は残ります）',
+                    ),
+                    value: settings.enableAdvancedMfm,
+                    onChanged: (value) {
+                      settings.enableAdvancedMfm = value;
+                    },
+                  ),
+                  SwitchListTile(
+                    title: const Text('アニメーション'),
+                    subtitle: const Text(
+                      'Advanced MFM がオンのときだけ有効。オフでは rainbow が静的な虹色になります',
+                    ),
+                    value: settings.enableAnimation,
+                    onChanged: (value) {
+                      settings.enableAnimation = value;
+                    },
+                  ),
+                  SwitchListTile(
+                    title: const Text('コードコピーボタン'),
+                    subtitle: const Text('コードブロック右上のコピーボタンを表示します'),
+                    value: settings.showCodeBlockCopyButton,
+                    onChanged: (value) {
+                      settings.showCodeBlockCopyButton = value;
+                    },
+                  ),
+                ],
+              ),
+            ),
+            _Section(
+              title: '投稿文脈',
+              child: Column(
+                children: [
+                  _SegmentedSetting<MfmNyaizeMode>(
+                    title: 'nyaize モード',
+                    subtitle: '投稿本文の語尾を猫らしい表現へ変換する方法です',
+                    selected: {settings.nyaizeMode},
+                    onSelectionChanged: (selection) {
+                      settings.nyaizeMode = selection.single;
+                    },
+                    segments: const [
+                      ButtonSegment(
+                        value: MfmNyaizeMode.disabled,
+                        label: Text('オフ'),
+                      ),
+                      ButtonSegment(
+                        value: MfmNyaizeMode.enabled,
+                        label: Text('オン'),
+                      ),
+                      ButtonSegment(
+                        value: MfmNyaizeMode.respectAuthor,
+                        label: Text('投稿者'),
+                      ),
+                    ],
+                  ),
+                  SwitchListTile(
+                    title: const Text('投稿者は猫'),
+                    subtitle: const Text('nyaize の「投稿者」モードで変換を有効にします'),
+                    value: settings.authorIsCat,
+                    onChanged: (value) {
+                      settings.authorIsCat = value;
+                    },
+                  ),
+                  SwitchListTile(
+                    title: const Text('リモート投稿として扱う'),
+                    subtitle: const Text(
+                      'author.host を misskey.example にします。カスタム絵文字は emojiUrls '
+                      'かリモート絵文字エンドポイントで解決されます',
+                    ),
+                    value: settings.remoteAuthor,
+                    onChanged: emojiInitialized
+                        ? (value) {
+                            settings.remoteAuthor = value;
+                          }
+                        : null,
+                  ),
+                  SwitchListTile(
+                    title: const Text('emojiUrls を渡す'),
+                    subtitle: const Text(
+                      'ai_smile_misskeyio と pudding_cat の URL を渡します。他の絵文字は'
+                      'ショートコードのまま表示されます（リモート投稿時のみ有効）',
+                    ),
+                    value: settings.useEmojiUrls,
+                    onChanged: emojiInitialized
+                        ? (value) {
+                            settings.useEmojiUrls = value;
+                          }
+                        : null,
+                  ),
+                  SwitchListTile(
+                    title: const Text('絵文字の文脈を表示'),
+                    subtitle: const Text(
+                      '絵文字にホバー/長押しで fontSize・scale・normal・host・url を表示します',
+                    ),
+                    value: settings.showEmojiContext,
+                    onChanged: (value) {
+                      settings.showEmojiContext = value;
+                    },
+                  ),
+                  SwitchListTile(
+                    title: const Text('isNote'),
+                    subtitle: const Text(
+                      'ハッシュタグの遷移先 path が /tags と /user-tags で切り替わります（コールバックの SnackBar で確認）',
+                    ),
+                    value: settings.isNote,
+                    onChanged: (value) {
+                      settings.isNote = value;
+                    },
+                  ),
+                ],
+              ),
+            ),
+            _Section(
+              title: 'MfmText',
+              child: Column(
+                children: [
+                  SwitchListTile(
+                    title: const Text('plain'),
+                    subtitle: const Text('構文を解釈せず、改行を空白にします'),
+                    value: settings.plain,
+                    onChanged: (value) {
+                      settings.plain = value;
+                    },
+                  ),
+                  SwitchListTile(
+                    title: const Text('nowrap'),
+                    subtitle: const Text('1 行に省略表示します（タイムラインのプレビュー向け）'),
+                    value: settings.nowrap,
+                    onChanged: (value) {
+                      settings.nowrap = value;
+                    },
+                  ),
+                  ListTile(
+                    title: const Text('rootScale'),
+                    subtitle: const Text(
+                      'emojiBuilder に渡る scale の初期値。既定のビルダーでは見た目は変わりません'
+                      '（文脈表示で確認できます）',
+                    ),
+                    trailing: DropdownButton<double>(
+                      value: settings.rootScale,
+                      onChanged: (value) {
+                        if (value != null) settings.rootScale = value;
+                      },
+                      items: const [
+                        DropdownMenuItem(value: 1, child: Text('1.0')),
+                        DropdownMenuItem(value: 2, child: Text('2.0')),
+                        DropdownMenuItem(value: 3, child: Text('3.0')),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(title, style: Theme.of(context).textTheme.titleSmall),
+          ),
+          const SizedBox(height: 4),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _SegmentedSetting<T> extends StatelessWidget {
+  const _SegmentedSetting({
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.onSelectionChanged,
+    required this.segments,
+  });
+
+  final String title;
+  final String subtitle;
+  final Set<T> selected;
+  final ValueChanged<Set<T>> onSelectionChanged;
+  final List<ButtonSegment<T>> segments;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 2),
+          Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: SegmentedButton<T>(
+              segments: segments,
+              selected: selected,
+              showSelectedIcon: false,
+              onSelectionChanged: onSelectionChanged,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/core/callbacks/example_callbacks.dart
+++ b/example/lib/core/callbacks/example_callbacks.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+class ExampleCallbacks {
+  const ExampleCallbacks(this.scaffoldMessengerKey);
+
+  final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey;
+
+  void onLinkTap(String url) => _show('リンク: $url');
+
+  void onMentionTap(String acct) => _show('メンション: $acct');
+
+  void onHashtagTapDetails(MfmHashtagTapDetails details) {
+    _show(
+      'ハッシュタグ: #${details.tag}（isNote=${details.isNote}, path=${details.path}）',
+    );
+  }
+
+  void onSearchTap(String query) => _show('検索: $query');
+
+  void onClickableEvent(String eventId) => _show('clickable: $eventId');
+
+  void _show(String message) {
+    final messenger = scaffoldMessengerKey.currentState;
+    if (messenger == null) return;
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+}

--- a/example/lib/core/settings/example_settings.dart
+++ b/example/lib/core/settings/example_settings.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+import '../callbacks/example_callbacks.dart';
+
+class ExampleSettings extends ChangeNotifier {
+  ThemeMode _themeMode = ThemeMode.system;
+  bool _useCustomColorScheme = false;
+  bool _enableAdvancedMfm = true;
+  bool _enableAnimation = true;
+  MfmNyaizeMode _nyaizeMode = MfmNyaizeMode.disabled;
+  bool _authorIsCat = false;
+  bool _remoteAuthor = false;
+  bool _useEmojiUrls = false;
+  bool _showEmojiContext = false;
+  bool _plain = false;
+  bool _nowrap = false;
+  double _rootScale = 1;
+  bool _isNote = true;
+  bool _showCodeBlockCopyButton = true;
+
+  ThemeMode get themeMode => _themeMode;
+  bool get useCustomColorScheme => _useCustomColorScheme;
+  bool get enableAdvancedMfm => _enableAdvancedMfm;
+  bool get enableAnimation => _enableAnimation;
+  MfmNyaizeMode get nyaizeMode => _nyaizeMode;
+  bool get authorIsCat => _authorIsCat;
+  bool get remoteAuthor => _remoteAuthor;
+  bool get useEmojiUrls => _useEmojiUrls;
+  bool get showEmojiContext => _showEmojiContext;
+  bool get plain => _plain;
+  bool get nowrap => _nowrap;
+  double get rootScale => _rootScale;
+  bool get isNote => _isNote;
+  bool get showCodeBlockCopyButton => _showCodeBlockCopyButton;
+
+  set themeMode(ThemeMode value) => _update(_themeMode, value, () {
+    _themeMode = value;
+  });
+
+  set useCustomColorScheme(bool value) =>
+      _update(_useCustomColorScheme, value, () {
+        _useCustomColorScheme = value;
+      });
+
+  set enableAdvancedMfm(bool value) => _update(_enableAdvancedMfm, value, () {
+    _enableAdvancedMfm = value;
+  });
+
+  set enableAnimation(bool value) => _update(_enableAnimation, value, () {
+    _enableAnimation = value;
+  });
+
+  set nyaizeMode(MfmNyaizeMode value) => _update(_nyaizeMode, value, () {
+    _nyaizeMode = value;
+  });
+
+  set authorIsCat(bool value) => _update(_authorIsCat, value, () {
+    _authorIsCat = value;
+  });
+
+  set remoteAuthor(bool value) => _update(_remoteAuthor, value, () {
+    _remoteAuthor = value;
+  });
+
+  set useEmojiUrls(bool value) => _update(_useEmojiUrls, value, () {
+    _useEmojiUrls = value;
+  });
+
+  set showEmojiContext(bool value) => _update(_showEmojiContext, value, () {
+    _showEmojiContext = value;
+  });
+
+  set plain(bool value) => _update(_plain, value, () {
+    _plain = value;
+  });
+
+  set nowrap(bool value) => _update(_nowrap, value, () {
+    _nowrap = value;
+  });
+
+  set rootScale(double value) => _update(_rootScale, value, () {
+    _rootScale = value;
+  });
+
+  set isNote(bool value) => _update(_isNote, value, () {
+    _isNote = value;
+  });
+
+  set showCodeBlockCopyButton(bool value) =>
+      _update(_showCodeBlockCopyButton, value, () {
+        _showCodeBlockCopyButton = value;
+      });
+
+  void reset() {
+    if (_themeMode == ThemeMode.system &&
+        !_useCustomColorScheme &&
+        _enableAdvancedMfm &&
+        _enableAnimation &&
+        _nyaizeMode == MfmNyaizeMode.disabled &&
+        !_authorIsCat &&
+        !_remoteAuthor &&
+        !_useEmojiUrls &&
+        !_showEmojiContext &&
+        !_plain &&
+        !_nowrap &&
+        _rootScale == 1 &&
+        _isNote &&
+        _showCodeBlockCopyButton) {
+      return;
+    }
+
+    _themeMode = ThemeMode.system;
+    _useCustomColorScheme = false;
+    _enableAdvancedMfm = true;
+    _enableAnimation = true;
+    _nyaizeMode = MfmNyaizeMode.disabled;
+    _authorIsCat = false;
+    _remoteAuthor = false;
+    _useEmojiUrls = false;
+    _showEmojiContext = false;
+    _plain = false;
+    _nowrap = false;
+    _rootScale = 1;
+    _isNote = true;
+    _showCodeBlockCopyButton = true;
+    notifyListeners();
+  }
+
+  void _update<T>(T current, T next, VoidCallback apply) {
+    if (current == next) return;
+    apply();
+    notifyListeners();
+  }
+}
+
+class ExampleSettingsScope extends InheritedNotifier<ExampleSettings> {
+  const ExampleSettingsScope({
+    super.key,
+    required ExampleSettings settings,
+    required super.child,
+  }) : super(notifier: settings);
+
+  static ExampleSettings? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<ExampleSettingsScope>()
+        ?.notifier;
+  }
+
+  static ExampleSettings of(BuildContext context) {
+    final settings = maybeOf(context);
+    assert(settings != null, 'No ExampleSettingsScope found in context');
+    return settings!;
+  }
+}
+
+MfmRenderConfig buildRenderConfig(
+  ExampleSettings settings,
+  MfmRenderConfig base,
+  ExampleCallbacks callbacks,
+) {
+  final baseBuilder = base.emojiBuilder;
+  final emojiBuilder = settings.showEmojiContext && baseBuilder != null
+      ? (String name, MfmEmojiContext context) => Tooltip(
+          message:
+              'fontSize=${context.fontSize} '
+              'scale=${context.scale} '
+              'normal=${context.normal} '
+              'host=${context.host ?? '-'} '
+              'url=${context.url ?? '-'}',
+          child: baseBuilder(name, context),
+        )
+      : null;
+
+  return base.copyWith(
+    enableAdvancedMfm: settings.enableAdvancedMfm,
+    enableAnimation: settings.enableAnimation,
+    nyaizeMode: settings.nyaizeMode,
+    author: MfmAuthorContext(
+      host: settings.remoteAuthor ? 'misskey.example' : null,
+      isCat: settings.authorIsCat,
+    ),
+    emojiUrls: settings.useEmojiUrls ? _emojiUrls : null,
+    clearEmojiUrls: !settings.useEmojiUrls,
+    emojiBuilder: emojiBuilder,
+    onLinkTap: callbacks.onLinkTap,
+    onMentionTap: callbacks.onMentionTap,
+    onHashtagTapDetails: callbacks.onHashtagTapDetails,
+    onSearchTap: callbacks.onSearchTap,
+    onClickableEvent: callbacks.onClickableEvent,
+    lightColorScheme: settings.useCustomColorScheme
+        ? _customLightColorScheme
+        : null,
+    darkColorScheme: settings.useCustomColorScheme
+        ? _customDarkColorScheme
+        : null,
+    showCodeBlockCopyButton: settings.showCodeBlockCopyButton,
+  );
+}
+
+const Map<String, String> _emojiUrls = {
+  'ai_smile_misskeyio': 'https://misskey.io/emoji/ai_smile_misskeyio.webp',
+  'pudding_cat': 'https://misskey.io/emoji/pudding_cat.webp',
+};
+
+final MfmColorScheme _customLightColorScheme = const MfmColorScheme.light()
+    .copyWith(
+      accent: const Color(0xFF7C3AED),
+      link: const Color(0xFF6D28D9),
+      hashtag: const Color(0xFFBE185D),
+      mention: const Color(0xFF8B5CF6),
+      mentionMe: const Color(0xFF4C1D95),
+      fg: const Color(0xFF3B2F52),
+      bg: const Color(0xFFF8F5FF),
+      divider: const Color(0xFFE9D5FF),
+      panel: const Color(0xFFFFFFFF),
+    );
+
+final MfmColorScheme _customDarkColorScheme = const MfmColorScheme.dark()
+    .copyWith(
+      accent: const Color(0xFFC4B5FD),
+      link: const Color(0xFFA78BFA),
+      hashtag: const Color(0xFFF9A8D4),
+      mention: const Color(0xFFC4B5FD),
+      mentionMe: const Color(0xFFE9D5FF),
+      fg: const Color(0xFFEDE9FE),
+      bg: const Color(0xFF20152F),
+      divider: const Color(0xFF4C3A62),
+      panel: const Color(0xFF2D1F42),
+    );

--- a/example/lib/core/widgets/mfm_preview_card.dart
+++ b/example/lib/core/widgets/mfm_preview_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
 
+import '../settings/example_settings.dart';
+
 /// MFMプレビューカード
 class MfmPreviewCard extends StatelessWidget {
   const MfmPreviewCard({
@@ -22,6 +24,7 @@ class MfmPreviewCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final settings = ExampleSettingsScope.of(context);
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -82,6 +85,10 @@ class MfmPreviewCard extends StatelessWidget {
             MfmText(
               text: mfm,
               config: config ?? const MfmRenderConfig(),
+              plain: settings.plain,
+              nowrap: settings.nowrap,
+              rootScale: settings.rootScale,
+              isNote: settings.isNote,
             ),
           ],
         ),

--- a/example/lib/features/playground/presentation/playground_tab.dart
+++ b/example/lib/features/playground/presentation/playground_tab.dart
@@ -24,6 +24,10 @@ class _PlaygroundTabState extends State<PlaygroundTab>
     super.initState();
     _controller.text = '''こんにちは！ 😊
 
+@user #tag https://example.org/path?q=1#frag
+
+\$[clickable.ev=hello タップ]
+
 **太字**や*斜体*も使えます。
 
 \$[x2 大きな文字]

--- a/example/lib/features/playground/presentation/widgets/mfm_preview_panel.dart
+++ b/example/lib/features/playground/presentation/widgets/mfm_preview_panel.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
 
+import '../../../../core/settings/example_settings.dart';
+
 /// MFMプレビューパネル
 class MfmPreviewPanel extends StatelessWidget {
   const MfmPreviewPanel({
@@ -15,6 +17,7 @@ class MfmPreviewPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final settings = ExampleSettingsScope.of(context);
 
     if (mfmText.isEmpty) {
       return Center(
@@ -32,6 +35,10 @@ class MfmPreviewPanel extends StatelessWidget {
       child: MfmText(
         text: mfmText,
         config: config ?? const MfmRenderConfig(),
+        plain: settings.plain,
+        nowrap: settings.nowrap,
+        rootScale: settings.rootScale,
+        isNote: settings.isNote,
       ),
     );
   }

--- a/example/test/app_smoke_test.dart
+++ b/example/test/app_smoke_test.dart
@@ -1,10 +1,14 @@
 import 'package:example/app/app.dart';
+import 'package:example/app/home_page.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
 
 void main() {
-  testWidgets('アプリが起動しカタログとプレイグラウンドのタブを表示する', (
-    tester,
-  ) async {
+  testWidgets('アプリが起動しカタログとプレイグラウンドを表示する', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(400, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
     await tester.pumpWidget(const MfmExampleApp());
     await tester.pump();
 
@@ -12,5 +16,45 @@ void main() {
     expect(find.text('カタログ'), findsOneWidget);
     expect(find.text('プレイグラウンド'), findsOneWidget);
     expect(find.text('テキスト整形'), findsOneWidget);
+    expect(find.text('Bold'), findsOneWidget);
+
+    await tester.tap(find.text('プレイグラウンド'));
+    await tester.pump();
+
+    expect(find.byType(TextField), findsOneWidget);
+  });
+
+  testWidgets('設定ドロワーから Advanced MFM を切り替える', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(const MfmExampleApp());
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('openSettingsDrawerButton')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text('表示設定'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('enableAdvancedMfmSwitch')));
+    await tester.pump();
+
+    final homeContext = tester.element(find.byType(HomePage));
+    expect(MfmConfig.of(homeContext).enableAdvancedMfm, isFalse);
+  });
+
+  testWidgets('幅に応じてナビゲーションを切り替える', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1000, 800));
+    await tester.pumpWidget(const MfmExampleApp());
+    await tester.pump();
+    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(find.byType(NavigationBar), findsNothing);
+
+    await tester.binding.setSurfaceSize(const Size(400, 800));
+    await tester.pump();
+    expect(find.byType(NavigationRail), findsNothing);
+    expect(find.byType(NavigationBar), findsOneWidget);
+
+    addTearDown(() => tester.binding.setSurfaceSize(null));
   });
 }

--- a/example/test/callbacks_test.dart
+++ b/example/test/callbacks_test.dart
@@ -1,0 +1,126 @@
+import 'package:example/core/callbacks/example_callbacks.dart';
+import 'package:example/core/settings/example_settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+void main() {
+  testWidgets('リンク、メンション、ハッシュタグのタップを表示する', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final messengerKey = GlobalKey<ScaffoldMessengerState>();
+    final config = _config(messengerKey);
+
+    await tester.pumpWidget(
+      _callbackApp(
+        messengerKey: messengerKey,
+        config: config,
+        text: 'https://example.org',
+      ),
+    );
+    await tester.tap(find.byType(RichText).first);
+    await tester.pump();
+    expect(find.text('リンク: https://example.org'), findsOneWidget);
+
+    await tester.pumpWidget(
+      _callbackApp(
+        messengerKey: messengerKey,
+        config: config,
+        text: '@user',
+      ),
+    );
+    await tester.tap(find.byType(RichText).first);
+    await tester.pump();
+    expect(find.text('メンション: @user'), findsOneWidget);
+
+    await tester.pumpWidget(
+      _callbackApp(messengerKey: messengerKey, config: config, text: '#tag'),
+    );
+    await tester.tap(find.byType(RichText).first);
+    await tester.pump();
+    expect(
+      find.text('ハッシュタグ: #tag（isNote=true, path=/tags/tag）'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('isNote に応じたハッシュタグの path を表示する', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+    await tester.pumpWidget(
+      _callbackApp(
+        messengerKey: messengerKey,
+        config: _config(messengerKey),
+        text: '#tag',
+        isNote: false,
+      ),
+    );
+
+    await tester.tap(find.byType(RichText).first);
+    await tester.pump();
+
+    expect(
+      find.text('ハッシュタグ: #tag（isNote=false, path=/user-tags/tag）'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('検索と clickable のタップを表示する', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final messengerKey = GlobalKey<ScaffoldMessengerState>();
+    final config = _config(
+      messengerKey,
+      base: const MfmRenderConfig(searchButtonLabel: '検索'),
+    );
+
+    await tester.pumpWidget(
+      _callbackApp(
+        messengerKey: messengerKey,
+        config: config,
+        text: 'Misskey [検索]',
+      ),
+    );
+    await tester.tap(find.text('検索'));
+    await tester.pump();
+    expect(find.text('検索: Misskey'), findsOneWidget);
+
+    await tester.pumpWidget(
+      _callbackApp(
+        messengerKey: messengerKey,
+        config: config,
+        text: r'$[clickable.ev=hello タップ]',
+      ),
+    );
+    await tester.tap(find.byType(GestureDetector).first);
+    await tester.pump();
+    expect(find.text('clickable: hello'), findsOneWidget);
+  });
+}
+
+MfmRenderConfig _config(
+  GlobalKey<ScaffoldMessengerState> messengerKey, {
+  MfmRenderConfig base = const MfmRenderConfig(),
+}) {
+  return buildRenderConfig(
+    ExampleSettings(),
+    base,
+    ExampleCallbacks(messengerKey),
+  );
+}
+
+Widget _callbackApp({
+  required GlobalKey<ScaffoldMessengerState> messengerKey,
+  required MfmRenderConfig config,
+  required String text,
+  bool isNote = true,
+}) {
+  return MaterialApp(
+    scaffoldMessengerKey: messengerKey,
+    home: Scaffold(
+      body: MfmText(text: text, config: config, isNote: isNote),
+    ),
+  );
+}

--- a/example/test/example_settings_test.dart
+++ b/example/test/example_settings_test.dart
@@ -1,0 +1,103 @@
+import 'package:example/core/callbacks/example_callbacks.dart';
+import 'package:example/core/settings/example_settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:misskey_mfm_renderer/misskey_mfm_renderer.dart';
+
+void main() {
+  final callbacks = ExampleCallbacks(GlobalKey<ScaffoldMessengerState>());
+
+  test('設定を MfmRenderConfig へ写像する', () {
+    final settings = ExampleSettings()
+      ..enableAdvancedMfm = false
+      ..enableAnimation = false
+      ..nyaizeMode = MfmNyaizeMode.respectAuthor
+      ..authorIsCat = true
+      ..remoteAuthor = true
+      ..useEmojiUrls = true
+      ..useCustomColorScheme = true
+      ..showCodeBlockCopyButton = false;
+
+    final config = buildRenderConfig(
+      settings,
+      const MfmRenderConfig(),
+      callbacks,
+    );
+
+    expect(config.enableAdvancedMfm, isFalse);
+    expect(config.enableAnimation, isFalse);
+    expect(config.nyaizeMode, MfmNyaizeMode.respectAuthor);
+    expect(
+      config.author,
+      const MfmAuthorContext(host: 'misskey.example', isCat: true),
+    );
+    expect(
+      config.emojiUrls,
+      {
+        'ai_smile_misskeyio':
+            'https://misskey.io/emoji/ai_smile_misskeyio.webp',
+        'pudding_cat': 'https://misskey.io/emoji/pudding_cat.webp',
+      },
+    );
+    expect(config.lightColorScheme?.accent, const Color(0xFF7C3AED));
+    expect(config.darkColorScheme?.accent, const Color(0xFFC4B5FD));
+    expect(config.showCodeBlockCopyButton, isFalse);
+  });
+
+  test('emojiUrls は解除し、ローカル投稿の author を保持する', () {
+    final settings = ExampleSettings()..authorIsCat = true;
+    final config = buildRenderConfig(
+      settings,
+      const MfmRenderConfig(emojiUrls: {'old': 'https://example.org/old.webp'}),
+      callbacks,
+    );
+
+    expect(config.emojiUrls, isNull);
+    expect(config.author, const MfmAuthorContext(isCat: true));
+  });
+
+  test('reset は既定値へ戻す', () {
+    final settings = ExampleSettings()
+      ..themeMode = ThemeMode.dark
+      ..useCustomColorScheme = true
+      ..enableAdvancedMfm = false
+      ..enableAnimation = false
+      ..nyaizeMode = MfmNyaizeMode.enabled
+      ..authorIsCat = true
+      ..remoteAuthor = true
+      ..useEmojiUrls = true
+      ..showEmojiContext = true
+      ..plain = true
+      ..nowrap = true
+      ..rootScale = 3
+      ..isNote = false
+      ..showCodeBlockCopyButton = false
+      ..reset();
+
+    expect(settings.themeMode, ThemeMode.system);
+    expect(settings.useCustomColorScheme, isFalse);
+    expect(settings.enableAdvancedMfm, isTrue);
+    expect(settings.enableAnimation, isTrue);
+    expect(settings.nyaizeMode, MfmNyaizeMode.disabled);
+    expect(settings.authorIsCat, isFalse);
+    expect(settings.remoteAuthor, isFalse);
+    expect(settings.useEmojiUrls, isFalse);
+    expect(settings.showEmojiContext, isFalse);
+    expect(settings.plain, isFalse);
+    expect(settings.nowrap, isFalse);
+    expect(settings.rootScale, 1);
+    expect(settings.isNote, isTrue);
+    expect(settings.showCodeBlockCopyButton, isTrue);
+  });
+
+  test('絵文字ビルダーがない base では文脈表示が無害', () {
+    final settings = ExampleSettings()..showEmojiContext = true;
+    final config = buildRenderConfig(
+      settings,
+      const MfmRenderConfig(),
+      callbacks,
+    );
+
+    expect(config.emojiBuilder, isNull);
+  });
+}


### PR DESCRIPTION
## 概要
example アプリに設定パネルを追加し、`MfmRenderConfig` と `MfmText` の各設定を実行時に切り替えて挙動を確認できるようにします。あわせて、これまで未設定だったタップコールバックの受信内容を SnackBar で表示し、広い画面では `NavigationRail` に切り替えます。

## 変更内容
- `ExampleSettings`（`ChangeNotifier`）と `ExampleSettingsScope`（`InheritedNotifier`）を追加。設定変更時に起動時の `base` 設定から `copyWith` で `MfmRenderConfig` を再生成し、`MfmConfig` で配布（`copyWith` の `null` は値の維持なので、前回の config から派生させない）
- 設定ドロワー（AppBar 右の tune アイコン）: テーマ（システム / ライト / ダーク）、カスタム配色（`lightColorScheme` / `darkColorScheme`）、Advanced MFM、アニメーション、コードコピーボタン、nyaize モード、投稿者は猫（`author.isCat`）、リモート投稿として扱う（`author.host`）、emojiUrls を渡す、絵文字の文脈を表示（`MfmEmojiContext` を Tooltip で表示）、isNote、plain、nowrap、rootScale（1.0 / 2.0 / 3.0）、リセット
- ドロワー先頭に絵文字の初期化状態を表示し、初期化失敗時はリモート絵文字関連のトグルを無効化
- `onLinkTap` / `onMentionTap` / `onHashtagTapDetails` / `onSearchTap` / `onClickableEvent` を設定し、受信内容を `scaffoldMessengerKey` 経由の SnackBar で表示
- 幅 600 以上で `NavigationRail`、未満で `NavigationBar`
- `MfmPreviewCard` / `MfmPreviewPanel` が `plain` / `nowrap` / `rootScale` / `isNote` を `MfmText` に渡す
- プレイグラウンドの初期テキストにコールバック確認用の行を追加
- テスト: 設定 → `MfmRenderConfig` の写像（`example_settings_test.dart`）、コールバックの SnackBar 表示と isNote による path の切替（`callbacks_test.dart`）、ドロワー操作とレスポンシブ切替（`app_smoke_test.dart`）

## 補足
- 設定の説明文は本体の実装に合わせています（Advanced MFM オフでも tada の 150% は残る、rootScale は既定ビルダーでは見た目が変わらない、など）。
- `MfmEmojiConfigHandle.copyWith` はリソースを共有するため、生成したコピーは dispose せず、起動時ハンドルの所有者（`EmojiService`）だけが dispose します。

## 検証
- `cd example && flutter test`: 10 件成功、`flutter analyze --fatal-infos`: No issues found（ルートも同様）
- `dart format --set-exit-if-changed .` / `git diff --check`: 成功
- iPhone 16 シミュレータでライト / ダークのカタログ表示を確認
- #92 / #93 と合流した状態で Android エミュレータ（Pixel, API 36）と macOS で起動し、設定ドロワーの表示、Advanced MFM オフ時の静的 rainbow、メンションタップの SnackBar（`メンション: @alice@misskey.io`）、`NavigationRail` 表示を確認

## Stack
- Depends on #91
- Base branch: `feature/example-test-baseline`
