### PR TITLE
docs: リリース前整備（CHANGELOGの並びとMfmRenderConfig設定表の補完）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- exampleアプリをmacOS / Linux / Windowsに対応させ、READMEにプラットフォームごとの注記（Web非対応、macOSのentitlement、Linux/Windowsの要件）を追加。
 - Mi Light / Mi Dark準拠の `MfmColorScheme` と `MfmRenderConfig.lightColorScheme` / `darkColorScheme` を追加し、リンク、メンション、ハッシュタグ、引用、検索、border fn、unixtime、インラインコードの色をlight/dark別に設定可能にした（#50）。
 - `MfmAuthorContext.isCat` と `MfmNyaizeMode`（`disabled` / `enabled` / `respectAuthor`）を追加。`nyaizeMode` が未指定の場合は既存の `enableNyaize` を後方互換で解釈し、`respectAuthor` は投稿者の `isCat` に従う（#39）。
 - `MfmText.plain`、`rootScale`、`isNote` を追加。plainは本家MkMfmと同様にsimple parser、TextNodeの改行の半角スペース化、カスタム絵文字のnormal表示を適用し、rootScaleは子孫の累積scaleを初期化する（#39）。
 - `MfmText.nowrap` を追加。1行表示、折り返し無効、はみ出し時の省略記号を有効にし、引用は余白・左罫線・opacityを保った自然なインライン幅で表示する（#39）。
 - `MfmHashtagTapDetails` と `onHashtagTapDetails` を追加。詳細コールバックはタグ、isNote、エンコード済みの `/tags/...` または `/user-tags/...` を受け取り、指定時は既存の `onHashtagTap` より優先する（#39）。
 - `MfmRenderConfig.emojiUrls`、`MfmCustomEmoji.url`、`MfmEmojiContext.host` / `url`、`MfmEmojiConfig.fromResolver(serverBaseUrl:)` を追加し、リモート投稿のカスタム絵文字の直接URLとローカルサーバー経由のフォールバックをサポート（#56）。
+- exampleアプリをmacOS / Linux / Windowsに対応させ、READMEにプラットフォームごとの注記（Web非対応、macOSのentitlement、Linux/Windowsの要件）を追加。
 
 ### Fixed
 - `rainbow` のアニメーションをグラデーション走査から、本家Misskeyと同じ `hue-rotate` → `contrast(150%)` → `saturate(150%)` の3段フィルタへ修正（#40、見た目の変更）。元の文字色を起点に色相が回るため、灰色や黒の本文では色相変化は見えず、暗い灰色が少し濃くなるだけ（黒は不変）。色付きのfg・リンク・カラー絵文字では色相変化が見える。正のdelay待機中はフィルタなしとし、無効時の虹色グラデーションは維持して本家と同じ7色7ストップへ整理した。

--- a/README.ja.md
+++ b/README.ja.md
@@ -751,13 +751,18 @@ void main() {
 | `onHashtagTapDetails` | `void Function(MfmHashtagTapDetails)?` | null | `tag`、`isNote`、エンコード済み遷移先`path`を受け取る推奨コールバック |
 | `emojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | カスタム絵文字ビルダー |
 | `unicodeEmojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | Unicode絵文字ビルダー |
+| `emojiUrls` | `Map<String, String>?` | null | カスタム絵文字名から直接画像URLへの辞書。リモート投稿でのみ使用し、Mapは不変として扱い更新時は新しいMapを渡す |
 | `onLinkTap` | `void Function(String)?` | null | リンクタップコールバック |
 | `onMentionTap` | `void Function(String)?` | null | メンションタップコールバック |
 | `onHashtagTap` | `void Function(String)?` | null | ハッシュタグタップコールバック |
 | `onSearchTap` | `void Function(String)?` | null | 検索タップコールバック |
+| `onClickableEvent` | `void Function(String)?` | null | `clickable` fn関数のイベントコールバック。`clickable.ev`引数の値を受け取る |
+| `showCodeBlockCopyButton` | `bool?` | true | コードブロックのコピーボタンを表示するか |
 | `onCodeCopied` | `void Function(String)?` | null | コードコピー完了コールバック。指定時は既定のSnackBarを置換し、未指定時はScaffoldMessengerの祖先がある場合のみ通知 |
 | `codeCopyTooltip` | `String?` | 現在のロケール | コードコピーボタンのアクセシビリティラベルの上書き（日本語は`コピー`、その他は`Copy`） |
 | `codeCopiedMessage` | `String?` | 現在のロケール | コピー完了時の既定のSnackBar文言上書き（日本語は`コードをコピーしました`、その他は`Copied to clipboard`） |
+| `codeTheme` | `Map<String, TextStyle>?` | githubテーマ | コードブロックのシンタックスハイライトテーマ（ライトモード） |
+| `codeDarkTheme` | `Map<String, TextStyle>?` | `codeTheme`、なければgithub-dark | コードブロックのシンタックスハイライトテーマ（ダークモード） |
 | `author` | `MfmAuthorContext?` | null | `host` / `isCat`を持ち、ホスト依存描画と`respectAuthor` nyaizeに使う投稿者情報 |
 | `localHost` | `String?` | null | ホスト解決のフォールバックとself URL短縮に使用するローカルMisskeyホスト |
 | `searchButtonLabel` | `String?` | 現在のロケール | 検索ボタンのラベル上書き（日本語は`検索`、その他は`Search`） |

--- a/README.md
+++ b/README.md
@@ -757,13 +757,18 @@ void main() {
 | `onHashtagTapDetails` | `void Function(MfmHashtagTapDetails)?` | null | Preferred hashtag callback with `tag`, `isNote`, and encoded route `path` |
 | `emojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | Custom emoji builder |
 | `unicodeEmojiBuilder` | `Widget Function(String, MfmEmojiContext)?` | null | Unicode emoji builder |
+| `emojiUrls` | `Map<String, String>?` | null | Direct image URLs keyed by custom emoji name, used for remote posts only. Treat the map as immutable and pass a new one to update |
 | `onLinkTap` | `void Function(String)?` | null | Link tap callback |
 | `onMentionTap` | `void Function(String)?` | null | Mention tap callback |
 | `onHashtagTap` | `void Function(String)?` | null | Hashtag tap callback |
 | `onSearchTap` | `void Function(String)?` | null | Search tap callback |
+| `onClickableEvent` | `void Function(String)?` | null | `clickable` fn callback; receives the value of the `clickable.ev` argument |
+| `showCodeBlockCopyButton` | `bool?` | true | Show the copy button on code blocks |
 | `onCodeCopied` | `void Function(String)?` | null | Code copy completion callback; replaces the default SnackBar, which requires a ScaffoldMessenger ancestor |
 | `codeCopyTooltip` | `String?` | current locale | Code copy button accessibility label override (`コピー` for Japanese, `Copy` otherwise) |
 | `codeCopiedMessage` | `String?` | current locale | Default copy SnackBar message override (`コードをコピーしました` for Japanese, `Copied to clipboard` otherwise) |
+| `codeTheme` | `Map<String, TextStyle>?` | github theme | Syntax highlight theme for code blocks in light mode |
+| `codeDarkTheme` | `Map<String, TextStyle>?` | `codeTheme`, then github-dark | Syntax highlight theme for code blocks in dark mode |
 | `author` | `MfmAuthorContext?` | null | Author context (`host`, `isCat`) used for host-dependent rendering and `respectAuthor` nyaize |
 | `localHost` | `String?` | null | Local Misskey host used as a host-resolution fallback and for self-URL shortening |
 | `searchButtonLabel` | `String?` | current locale | Search button label override (`検索` for Japanese, `Search` otherwise) |


### PR DESCRIPTION
## 概要

0.6.0-beta.2 のリリース前整備として、リリースノートの並びと `MfmRenderConfig` の設定表の抜けを修正する。

## 変更内容

- CHANGELOG の Unreleased / Added で、example アプリのデスクトップ対応を末尾へ移動。リリースノートはこの節がそのまま使われるため、ライブラリの API 追加が先に並ぶようにした
- README.md / README.ja.md の `MfmRenderConfig` 表へ、未記載だった 5 件のオプションを追記
  - `emojiUrls`（`unicodeEmojiBuilder` の直後）
  - `onClickableEvent`、`showCodeBlockCopyButton`（`onSearchTap` と `onCodeCopied` の間）
  - `codeTheme`、`codeDarkTheme`（`codeCopiedMessage` の後）

いずれも既存オプションの記載漏れであり、ライブラリの挙動は変更していない。

## 補足

`showCodeBlockCopyButton` / `codeTheme` / `codeDarkTheme` / `onClickableEvent` は 0.6.0-beta.1 以前から存在する。`emojiUrls` は #56 で追加され、README 本文では説明済みだったが設定表にのみ記載がなかった。

## 検証

- `MfmRenderConfig` の final フィールド 27 件がすべて表に存在することを確認（差分 0）
- README.md と README.ja.md の行セットが一致（各 29 行）
- `dart run tool/verify_release.dart 0.6.0-beta.1` → consistent（CHANGELOG の並び替え後もリリースツールが解釈可能）
- `flutter test test/tool/release_project_test.dart` → 11 passed
- `flutter analyze --fatal-infos` → No issues found
- `git diff --check` → 問題なし
