### PR TITLE
chore: 0.6.0-beta.2のバージョン対応をdevelopへ反映

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0-beta.2] - 2026-09-12
+
 ### Added
 - Mi Light / Mi Dark準拠の `MfmColorScheme` と `MfmRenderConfig.lightColorScheme` / `darkColorScheme` を追加し、リンク、メンション、ハッシュタグ、引用、検索、border fn、unixtime、インラインコードの色をlight/dark別に設定可能にした（#50）。
 - `MfmAuthorContext.isCat` と `MfmNyaizeMode`（`disabled` / `enabled` / `respectAuthor`）を追加。`nyaizeMode` が未指定の場合は既存の `enableNyaize` を後方互換で解釈し、`respectAuthor` は投稿者の `isCat` に従う（#39）。

--- a/README.ja.md
+++ b/README.ja.md
@@ -162,7 +162,7 @@ Flutter 3.38.7 を使用していますが、パッケージの対応下限は F
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.6.0-beta.1
+  misskey_mfm_renderer: ^0.6.0-beta.2
   misskey_client: ^1.0.0-beta.5
 ```
 
@@ -392,7 +392,7 @@ import対象パッケージを直接依存に置きたい場合は追加して�
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.6.0-beta.1
+  misskey_mfm_renderer: ^0.6.0-beta.2
   misskey_client: ^1.0.0-beta.5
   misskey_emoji: ^2.0.0-beta.1
   path_provider: ^2.1.5

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.6.0-beta.1
+  misskey_mfm_renderer: ^0.6.0-beta.2
   misskey_client: ^1.0.0-beta.5
 ```
 
@@ -397,7 +397,7 @@ If your project enforces direct dependencies for imported packages, add:
 
 ```yaml
 dependencies:
-  misskey_mfm_renderer: ^0.6.0-beta.1
+  misskey_mfm_renderer: ^0.6.0-beta.2
   misskey_client: ^1.0.0-beta.5
   misskey_emoji: ^2.0.0-beta.1
   path_provider: ^2.1.5

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.0-beta.1"
+    version: "0.6.0-beta.2"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: misskey_mfm_renderer
 description: Flutter widget renderer for Misskey MFM (Misskey Flavored Markdown)
-version: 0.6.0-beta.1
+version: 0.6.0-beta.2
 repository: https://github.com/LibraryLibrarian/misskey_mfm_renderer
 
 environment:


### PR DESCRIPTION
## 概要

main へリリース済みの 0.6.0-beta.2 のバージョン対応を develop へ反映し、develop 上のバージョン参照を beta.2 に揃える。

0.6.0-beta.1 のときも同様にバージョン対応コミットが develop に入っており、その形に合わせる。

## 変更内容

`release/0.6.0-beta.2` の `docs: 0.6.0-beta.2のバージョン対応` をそのまま取り込む。

- `pubspec.yaml` の `version`
- `README.md` / `README.ja.md` の依存関係サンプル
- `CHANGELOG.md` の `## [0.6.0-beta.2] - 2026-09-12` 見出し
- `example/pubspec.lock` の path 依存バージョン

新規の変更は含まない（main にマージ済みの内容と同一）。

## 補足

反映後、develop でも `dart run tool/verify_release.dart 0.6.0-beta.2` が通る状態になる。

## 検証

- main へのマージ前に `flutter test` 837 passed / `flutter analyze --fatal-infos` No issues / `dart format --set-exit-if-changed .` 差分なしを確認済み
- リリース PR #96 の CI は 5 ジョブすべて success
