### PR TITLE
ci: リリースノートへのビルドフック出力混入を修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,10 +48,22 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      # リダイレクトを使うとdart runのビルドフック進捗がノートへ混入するため、
+      # 出力先はツールへ直接渡す
       - name: Extract release notes
         run: >-
           dart run tool/release_notes.dart "${GITHUB_REF_NAME#v}"
-          > "$RUNNER_TEMP/release-notes.md"
+          "$RUNNER_TEMP/release-notes.md"
+
+      # 想定外の出力が混入した場合はRelease作成前に止める
+      - name: Validate release notes
+        run: |
+          notes="$RUNNER_TEMP/release-notes.md"
+          if [[ ! -s "$notes" || "$(head -c 1 "$notes")" != "#" ]]; then
+            echo "::error::Release notes must start with a Markdown heading."
+            head -c 200 "$notes"
+            exit 1
+          fi
 
       - name: Create GitHub Release
         env:

--- a/tool/release_notes.dart
+++ b/tool/release_notes.dart
@@ -3,17 +3,28 @@ import 'dart:io';
 import 'src/release_project.dart';
 
 void main(List<String> arguments) {
-  if (arguments.length != 1) {
+  if (arguments.isEmpty || arguments.length > 2) {
     stderr.writeln(
-      'Usage: dart run tool/release_notes.dart <version>\n'
-      'Example: dart run tool/release_notes.dart 1.0.0-beta.4',
+      'Usage: dart run tool/release_notes.dart <version> [output-path]\n'
+      'Example: dart run tool/release_notes.dart 1.0.0-beta.4\n'
+      'Example: dart run tool/release_notes.dart 1.0.0-beta.4 notes.md',
     );
     exitCode = 64;
     return;
   }
 
+  final version = arguments.first;
+  // dart runはnative assetsのビルド進捗をstdoutへ出すため、出力先が指定された
+  // 場合はリダイレクトに頼らずツール側でファイルへ書き出す
+  final outputPath = arguments.length == 2 ? arguments[1] : null;
+
   try {
-    stdout.write(extractReleaseNotes(Directory.current, arguments.single));
+    final notes = extractReleaseNotes(Directory.current, version);
+    if (outputPath == null) {
+      stdout.write(notes);
+    } else {
+      File(outputPath).writeAsStringSync(notes);
+    }
   } on ReleaseToolException catch (error) {
     stderr.writeln('Release note extraction failed: ${error.message}');
     exitCode = 1;


### PR DESCRIPTION
## 概要

v0.6.0-beta.2 のリリースで、GitHub Release の本文先頭に `Running build hooks...Running build hooks...` が混入し、`### Added` が見出しとして描画されない問題が発生した。再発を防ぐため、リリースノートの生成経路を修正する。

原因は `publish.yml` の

```
dart run tool/release_notes.dart "${GITHUB_REF_NAME#v}" > "$RUNNER_TEMP/release-notes.md"
```

で、`dart run` が native assets のビルドフック進捗を **stdout** へ出力するため、それがリダイレクト先のファイルへ入り込んでいた。ローカルではビルドフックが既にキャッシュ済みで進捗が出ないため、事前検証では再現しなかった。

なお、公開済みの v0.6.0-beta.2 の Release 本文は正しい内容へ差し替え済み。

## 変更内容

- `tool/release_notes.dart` に出力先パスの任意指定（第2引数）を追加。指定時はリダイレクトに頼らずツール側で `File.writeAsStringSync` する。引数なしの従来どおりの stdout 出力も維持する
- `.github/workflows/publish.yml` の Extract release notes をリダイレクトからパス渡しへ変更
- `Validate release notes` ステップを追加。ノートが空、または先頭が `#` でない場合は Release 作成前に失敗させる

## 補足

`Validate release notes` は今回の原因に限らず、想定外の出力が混入した場合の一般的な検知として機能する。GitHub Release は後から編集できるが、pub.dev への publish はその前段で完了しているため、Release 作成前に止める位置に置いた。

## 検証

- 第2引数あり: `dart run tool/release_notes.dart 0.5.0 <path>` → 生成ファイルの先頭が `### Added\n`（`od -c` で確認）
- 第2引数なし: 従来どおり stdout へ出力されることを確認
- 引数 0 個 / 3 個: usage を stderr へ出力し exit 64
- 存在しないバージョン: エラー終了（exit 1）し、出力ファイルを作成しない
- `Validate release notes` のシェル判定をローカルで再現し、正常なノートは通過、`Running build hooks...### Added` および空ファイルは失敗することを確認
- `publish.yml` が YAML として解釈でき、release ジョブのステップ順が Install → Extract → Validate → Create になることを確認
- `flutter test test/tool/release_project_test.dart` → 11 passed
- `flutter analyze --fatal-infos` → No issues found
- `dart format --set-exit-if-changed .` → 差分なし
- `git diff --check` → 問題なし
